### PR TITLE
docs: inline links for easier reading and maintainability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,14 @@ npm test
 
 ### Formatting
 
-- [ESLint] is used in the project to enforce code style and should be
+- [ESLint](https://eslint.org/) is used in the project to enforce code style and should be
   configured in your [editor](https://eslint.org/docs/user-guide/integrations).
-- [Prettier] is also used and apply automatically by ESLint.
+- [Prettier](https://prettier.io/) is also used and apply automatically by ESLint.
 
 We also use a number of framework plugins:
 
-- [TypeScript ESLint]
-- [Angular ESLint]
+- [TypeScript ESLint](https://github.com/typescript-eslint/typescript-eslint)
+- [Angular ESLint](https://github.com/angular-eslint/angular-eslint)
 
 You can check this manually by running:
 
@@ -57,8 +57,3 @@ Please note that not all issues can be fixed by ESLint and Prettier.
 ## Migrating components
 
 See [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md)
-
-[ESLint](https://eslint.org/)
-[Prettier](https://prettier.io/)
-[TypeScript ESLint](https://github.com/typescript-eslint/typescript-eslint)
-[Angular ESLint](https://github.com/angular-eslint/angular-eslint)


### PR DESCRIPTION
# Description

Fix broken identifier links in the `CONTRIBUTING` doc. This PR also replaces the identifier with inline links for easier reading and maintainability. 

## Type of change

- [x] Doc change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
