### PR TITLE
fix: scroll into view error

### DIFF
--- a/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
+++ b/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
@@ -48,7 +48,7 @@ angular.module('doubtfire.projects.states.dashboard.directives.student-task-list
       return unless taskEl?
       funcName = if taskEl.scrollIntoViewIfNeeded? then 'scrollIntoViewIfNeeded' else if taskEl.scrollIntoView? then 'scrollIntoView'
       return unless funcName?
-      taskEl[funcName]({behavior: 'smooth', block: 'top'})
+      taskEl[funcName]({behavior: 'smooth', block: 'start'})
     $timeout ->
       scrollToTaskInList($scope.taskData.selectedTask) if $scope.taskData.selectedTask?
     $scope.isSelectedTask = (task) ->

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
@@ -304,7 +304,7 @@ export class StaffTaskListComponent implements OnInit, OnChanges {
     if (!funcName) {
       return;
     }
-    taskEl[funcName]({ behavior: 'smooth', block: 'top' });
+    taskEl[funcName]({ behavior: 'smooth', block: 'start' });
   }
 
   isSelectedTask(task) {


### PR DESCRIPTION
# Description

This pull request fixes the `Element.scrollIntoView` error that is logged to the browser console every time a task item is clicked on. The optional `block` value (which is responsible for vertical alignment) [does not contain](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) a `top` option, and should be `start` instead. 
<img width="534" alt="image" src="https://user-images.githubusercontent.com/49971210/169629617-c6219f74-9dd4-4102-8b8f-e1ac9a727640.png">. 
The `scrollIntoView` appears to only work in Firefox.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in Chrome, Safari & Firefox. Error does not appear in Firefox anymore.

## Testing Checklist:

- [X] Tested in latest Chrome
- [X] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @RayGuo-ergou  and @tancnle  on the Pull Request
