### PR TITLE
docs: remove direct ping to Doubtfire's maintainer

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -32,4 +32,4 @@ _Please describe the tests that you ran to verify your changes. Provide instruct
 - [ ] I have commented my code in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
+- [ ] I have requested a review from team members on the Pull Request


### PR DESCRIPTION
# Description

Remove direct pings to Doubtfire's maintainer in the Pull Request templates. Considering that we only do internal review within Thoth Tech, this creates unnecessary noises for them.

/cc @macite @jakerenzella 

## Type of change

- [x] Documentation update
