### PR TITLE
chore: remove unused underscore dependency

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,6 @@
               "node_modules/moment/moment.js",
               "node_modules/d3/d3.js",
               "node_modules/lodash/lodash.js",
-              "node_modules/underscore.string/dist/underscore.string.min.js",
               "node_modules/nvd3/build/nv.d3.js",
               "node_modules/es5-shim/es5-shim.js",
               "node_modules/codemirror/lib/codemirror.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "showdown": "1.3.0",
         "ts-md5": "^1.2.7",
         "tslib": "^2.3.1",
-        "underscore.string": "2.3.3",
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
@@ -140,8 +139,7 @@
         "protractor": "~7.0.0",
         "sass": "^1.48.0",
         "ts-node": "~10.1.0",
-        "typescript": "~4.5.4",
-        "underscore": "^1.8.3"
+        "typescript": "~4.5.4"
       },
       "engines": {
         "node": ">=16"
@@ -26020,12 +26018,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
-      "dev": true
-    },
     "node_modules/underscore.string": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
@@ -46898,12 +46890,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "showdown": "1.3.0",
     "ts-md5": "^1.2.7",
     "tslib": "^2.3.1",
-    "underscore.string": "2.3.3",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
@@ -157,7 +156,6 @@
     "protractor": "~7.0.0",
     "sass": "^1.48.0",
     "ts-node": "~10.1.0",
-    "typescript": "~4.5.4",
-    "underscore": "^1.8.3"
+    "typescript": "~4.5.4"
   }
 }


### PR DESCRIPTION
# Description

Remove redundant `lodash` and `underscore` dependency.

## Type of change

- [x] Maintenance

# How Has This Been Tested?

All tests are passing via `npm test`.

This change also helps to reduce the JS assets downloaded by the users (`scripts.js` from 2.20 MB to 1.67 MB).

```shell
npm run build 

<snip>
# Before
Initial Chunk Files | Names         |  Raw Size
vendor.js           | vendor        |   9.63 MB |
scripts.js          | scripts       |   2.20 MB |
main.js             | main          |   2.05 MB |
styles.css          | styles        |   1.03 MB |
polyfills.js        | polyfills     | 126.79 kB |
runtime.js          | runtime       |   6.71 kB |

| Initial Total |  15.04 MB

# After
Initial Chunk Files | Names         |  Raw Size
vendor.js           | vendor        |   9.63 MB |
main.js             | main          |   2.05 MB |
scripts.js          | scripts       |   1.67 MB |
styles.css          | styles        |   1.03 MB |
polyfills.js        | polyfills     | 126.79 kB |
runtime.js          | runtime       |   6.71 kB |

| Initial Total |  14.51 MB
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
