### PR TITLE
refactor: migration task-comment-composer

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.html
@@ -1,5 +1,13 @@
-<emoji-mart [darkMode]="false" [isNative]="true" [hideRecent]="false" [hidden]="!this.showEmojiPicker"
-  class="emoji-picker" title="Pick your emoji…" emoji="thumbsup" (emojiSelect)="addEmoji($event)"></emoji-mart>
+<emoji-mart
+  [darkMode]="false"
+  [isNative]="true"
+  [hideRecent]="false"
+  [hidden]="!showEmojiPicker"
+  class="emoji-picker"
+  title="Pick your emoji…"
+  emoji="thumbsup"
+  (emojiSelect)="addEmoji($event)"
+></emoji-mart>
 
 <div id="replyContainer" *ngIf="task" [hidden]="originalComment === null">
   <div>
@@ -16,26 +24,38 @@
 
 <mat-action-list [hidden]="!emojiSearchMode || !(emojiSearchResults?.length > 0)" dense id="emojiSearchResults">
   <mat-list-item *ngFor="let emoji of emojiSearchResults" (click)="emojiSelected(emoji.native)">
-    <div fxLayout="row" fxLayoutAlign="start center">
+    <div class="flex items-center">
       <ngx-emoji style="align-items: center" [emoji]="emoji" set="apple" size="20"></ngx-emoji>
-      <div class="emoji-details" fxLayout="column" fxLayoutAlign="center start">
-        <div style="font-weight: 500; font-size: 12px">{{ emoji.name }}</div>
-        <div style="font-size: 10px">{{ emoji.colons }}</div>
+      <div class="emoji-details flex flex-col items-center">
+        <div class="font-medium text-xs">{{ emoji.name }}</div>
+        <div class="text-xs">{{ emoji.colons }}</div>
       </div>
     </div>
   </mat-list-item>
 </mat-action-list>
 
-<form [hidden]="!this.task" style="display: flex; width: 100%" class="input-group col-sm-12 comment-submitter"
-  ng-submit="addComment()" role="form">
-  <div fxLayout="row" fxLayoutAlign="space-around center" class="composer-container">
+<form
+  [hidden]="!task"
+  style="display: flex; width: 100%"
+  class="input-group col-sm-12 comment-submitter"
+  ng-submit="addComment()"
+  role="form"
+>
+  <div class="flex items-center justify-around composer-container">
     <div class="composer-action-group" [@shrinkgrow]="$expandInput | async">
-      <!-- if active -->
-      <div fxLayout="row" fxLayoutAlign="start center">
-        <button [hidden]="($expandInput | async) === false" (click)="$expandInput.next(false); recording = false"
-          matTooltip="Expand action buttons" matTooltipShowDelay="400" mat-icon-button class="btn-no-outline"
-          type="button" aria-label="Expand action buttons" style="margin-right: -4px; margin-left: -4px">
-          <mat-icon>{{recording ? 'cancel' : 'chevron_right'}}</mat-icon>
+      <div class="flex items-center">
+        <button
+          [hidden]="($expandInput | async) === false"
+          (click)="$expandInput.next(false); recording = false"
+          matTooltip="Expand action buttons"
+          matTooltipShowDelay="400"
+          mat-icon-button
+          class="btn-no-outline"
+          type="button"
+          aria-label="Expand action buttons"
+          style="margin-right: -4px; margin-left: -4px"
+        >
+          <mat-icon>{{ recording ? 'cancel' : 'chevron_right' }}</mat-icon>
         </button>
 
         <!-- <button
@@ -52,38 +72,83 @@
           <mat-icon>crisis_alert</mat-icon>
         </button> -->
 
-        <button [hidden]="$expandInput | async" *ngIf="isStaff" matTooltip="Create a Real Talk discussion"
-          matTooltipShowDelay="400" mat-icon-button class="btn-no-outline" type="button"
-          aria-label="launch real talk took" (click)="openDiscussionComposer()">
+        <button
+          [hidden]="$expandInput | async"
+          *ngIf="isStaff"
+          matTooltip="Create a Real Talk discussion"
+          matTooltipShowDelay="400"
+          mat-icon-button
+          class="btn-no-outline"
+          type="button"
+          aria-label="launch real talk tool"
+          (click)="openDiscussionComposer()"
+        >
           <mat-icon class="message-inbox-icon">mark_chat_read</mat-icon>
         </button>
-
-        <button [hidden]="$expandInput | async" matTooltip="Attach a file" matTooltipShowDelay="400" mat-icon-button
-          class="btn-no-outline" type="button" (click)="openFile()" aria-label="attach a file icon button">
+        <button
+          [hidden]="$expandInput | async"
+          matTooltip="Attach a file"
+          matTooltipShowDelay="400"
+          mat-icon-button
+          class="btn-no-outline"
+          type="button"
+          (click)="openFile()"
+          aria-label="attach a file icon button"
+        >
           <mat-icon class="message-inbox-icon">attach_file</mat-icon>
-          <input #uploader type="file" multiple="multiple" accept="audio/*,image/*,.pdf" style="display: none"
-            (change)="uploadFiles($event.target.files)" />
+          <input
+            #uploader
+            type="file"
+            multiple="multiple"
+            accept="audio/*,image/*,.pdf"
+            style="display: none"
+            (change)="uploadFiles($event.target.files)"
+          />
         </button>
-
-        <button [hidden]="$expandInput | async" matTooltip="Send a recording" matTooltipShowDelay="400" mat-icon-button
-          class="btn-no-outline" type="button" aria-label="audio recording button" (click)="recordingMode()">
+        <button
+          [hidden]="$expandInput | async"
+          matTooltip="Send a recording"
+          matTooltipShowDelay="400"
+          mat-icon-button
+          class="btn-no-outline"
+          type="button"
+          aria-label="audio recording button"
+          (click)="recordingMode()"
+        >
           <mat-icon class="message-inbox-icon">mic</mat-icon>
         </button>
       </div>
     </div>
     <div id="textFieldContainer" [class.active]="$expandInput | async" [ngClass]="{ recording: recording }">
-      <div [hidden]="recording" (focus)="$expandInput.next(true)" (blur)="$expandInput.next(false)"
-        [class.active]="($expandInput | async) === false" #commentInput id="textField"
-        [attr.contenteditable]="contentEditableValue() && !recording" (keydown.enter)="send($event)"
-        (keydown)="keyTyped()" placeholder="Aa" name="commentComposer">
-
-      </div>
-      <audio-comment-recorder style="display: flex;
-      justify-content: center; width: 100%" *ngIf="recording" [task]="task"></audio-comment-recorder>
+      <div
+        [hidden]="recording"
+        (focus)="$expandInput.next(true)"
+        (blur)="$expandInput.next(false)"
+        [class.active]="($expandInput | async) === false"
+        #commentInput
+        id="textField"
+        [attr.contenteditable]="contentEditableValue() && !recording"
+        (keydown.enter)="send($event)"
+        (keydown)="keyTyped()"
+        placeholder="Aa"
+        name="commentComposer"
+      ></div>
+      <audio-comment-recorder
+        class="flex justify-center w-full"
+        *ngIf="recording"
+        [task]="task"
+      ></audio-comment-recorder>
       <div id="innerButtons" [hidden]="recording">
-        <mat-icon matTooltip="Choose an emoji" matTooltipShowDelay="400" id="emojiButton"
-          (click)="this.showEmojiPicker = !this.showEmojiPicker" aria-hidden="false" aria-label="Emoji picker button">
-          emoji_emotions</mat-icon>
+        <mat-icon
+          matTooltip="Choose an emoji"
+          matTooltipShowDelay="400"
+          id="emojiButton"
+          (click)="showEmojiPicker = !showEmojiPicker"
+          aria-hidden="false"
+          aria-label="Emoji picker button"
+        >
+          emoji_emotions
+        </mat-icon>
       </div>
     </div>
   </div>

--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.scss
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.scss
@@ -1,3 +1,7 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+
 $emoji-color: lighten(
   $color: black,
   $amount: 25,
@@ -18,7 +22,7 @@ $emoji-color: lighten(
   }
 
   #textFieldContainer.recording {
-    background-color: #3939FF;
+    background-color: #3939ff;
   }
 
   #textField {

--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.scss
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.scss
@@ -1,7 +1,3 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
-
 $emoji-color: lighten(
   $color: black,
   $amount: 25,


### PR DESCRIPTION
refactor: migration task-comment-composer
Removal of fx-layout and addition of tailwind components 

# Description

Replaced fx-layout with tailwind equivalent for the task- comment composer 

- Used CSS classes instead of flex layout directives to control the layout and styling.

Fixes # (issue)
- Changed the old fx-layout styling with the use of tailwind classes 

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request


Before screenshot:
<img width="1240" alt="Before" src="https://github.com/thoth-tech/doubtfire-web/assets/83420282/93c0ed30-5b47-4f28-a892-f19b0aa04d39">

After Screenshot:
<img width="1243" alt="After" src="https://github.com/thoth-tech/doubtfire-web/assets/83420282/6b04bad5-06c6-4c01-a64d-d38e14483dbc">
