### PR TITLE
Feat: Give students in group permission to lock & unlock

### DIFF
--- a/src/app/groups/group-selector/group-selector.coffee
+++ b/src/app/groups/group-selector/group-selector.coffee
@@ -195,11 +195,12 @@ angular.module('doubtfire.groups.group-selector', [])
     # Toggle lockable group
     $scope.toggleLocked = (group) ->
       group.locked = !group.locked
-      $scope.unit.updateGroup(group,
-        (success) ->
-          group.locked = success.locked
-          alertService.add("success", "Group updated", 2000)
-      )
+      newGroupService.update(group).subscribe({
+        next: (response) ->
+          alertService.add("success", "#{if response.locked then 'Locked' else 'Unlocked'} #{group.name}", 2000)
+          applyFilters()
+        error: (message) -> alertService.add("danger", "Failed to #{if group.locked then 'unlock' else 'lock'} #{group.name}. #{message}", 6000)
+      })
 
     # Watch selected group set changes
     listeners.push $scope.$on 'UnitGroupSetEditor/SelectedGroupSetChanged', (evt, args) ->

--- a/src/app/groups/group-selector/group-selector.tpl.html
+++ b/src/app/groups/group-selector/group-selector.tpl.html
@@ -158,7 +158,7 @@
             editable-form
             name="groupRowForm"
             onbeforesave="updateGroup($data, group)"
-            ng-show="groupRowForm.$visible && unitRole"
+            ng-show="groupRowForm.$visible"
             shown="inserted.id == group.id"
           >
             <button type="submit" ng-disabled="groupRowForm.$waiting" class="btn btn-default btn-sm">

--- a/src/app/groups/group-selector/group-selector.tpl.html
+++ b/src/app/groups/group-selector/group-selector.tpl.html
@@ -153,12 +153,12 @@
             </button>
           </span>
         </div>
-        <div ng-show="unitRole">
+        <div ng-show="(project && selectedGroupSet.allowStudentsToManageGroups) || unitRole">
           <form
             editable-form
             name="groupRowForm"
             onbeforesave="updateGroup($data, group)"
-            ng-show="groupRowForm.$visible"
+            ng-show="groupRowForm.$visible && unitRole"
             shown="inserted.id == group.id"
           >
             <button type="submit" ng-disabled="groupRowForm.$waiting" class="btn btn-default btn-sm">
@@ -174,7 +174,7 @@
             </button>
           </form>
           <div ng-hide="groupRowForm.$visible">
-            <button ng-click="groupRowForm.$show()" class="btn btn-default btn-sm">
+            <button ng-click="groupRowForm.$show()" class="btn btn-default btn-sm" ng-show = "unitRole">
               <i class="fa fa-pencil"></i> Edit
             </button>
             <a
@@ -185,7 +185,7 @@
               <i ng-class="{true: 'fa fa-lock', false: 'fa fa-unlock'}[!group.locked]"></i>
               {{!group.locked && "Lock" || "Unlock"}}
             </a>
-            <button ng-click="deleteGroup(group)" class="btn btn-danger btn-sm">
+            <button ng-click="deleteGroup(group)" class="btn btn-danger btn-sm" ng-show = "unitRole">
               <i class="fa fa-trash-o"></i> Delete
             </button>
           </div>


### PR DESCRIPTION
# Description
To give permission to lock and unlock a group for student, we need to make changes for the front-end and back-end:
Front-end:
- Make the lock button visible in the group-selector.tpl.html file and hide the others
- In 'group-selector.coffee' fix the '$scope.toggleLocked' method as the old one doesn't work when called

Back-end:
- In 'group.rb' add ':lock_group' permission in the 'student_role_permissions' array

Front-end PR: https://github.com/thoth-tech/doubtfire-web/pull/82
Back-end PR: https://github.com/thoth-tech/doubtfire-api/pull/6

Video demo:

https://github.com/thoth-tech/doubtfire-web/assets/128771372/58d45115-42a4-4aa4-8941-7082a3bf6720

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] Tested both students and convenor account

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Requested review from seniors
