### PR TITLE
refactor(style): replace fxLayout with tailwind equivalent - hero-sidebar component

### DIFF
--- a/src/app/common/hero-sidebar/hero-sidebar.component.html
+++ b/src/app/common/hero-sidebar/hero-sidebar.component.html
@@ -1,12 +1,13 @@
-<div class="left-banner" fxLayout="column">
+<div class="left-banner flex flex-col">
   <div class="header">
-    <div class="wordmark" fxLayout="row" fxLayoutAlign="start center">
+    <div class="wordmark flex justify-start items-center">
       <img src="../../../assets/images/logo-white.svg" width="40px" alt="Homepage Logo" style="padding-right: 6px" />
       <p>{{ externalName.value }}</p>
     </div>
     <h1 class="mt-6">Manage your learning, with feedback you'll want to receive.</h1>
   </div>
 
-  <div fxFlex="10"></div>
-  <div fxFlex="grow" class="pattern"></div>
+  <!-- <div fxFlex="10"></div> -->
+  <div class="h-1/10"></div>
+  <div class="pattern flex-grow"></div>
 </div>

--- a/src/app/common/hero-sidebar/hero-sidebar.component.html
+++ b/src/app/common/hero-sidebar/hero-sidebar.component.html
@@ -7,7 +7,6 @@
     <h1 class="mt-6">Manage your learning, with feedback you'll want to receive.</h1>
   </div>
 
-  <!-- <div fxFlex="10"></div> -->
-  <div class="h-1/10"></div>
+  <div class="flex-1" style="max-height: 10%;"></div>
   <div class="pattern flex-grow"></div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
         'formatif-blue': '#3939ff',
         'formatif-blue-lighter': '#e7e7ff',
       },
+      height: {
+        '1/10': '10%',
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,9 +8,6 @@ module.exports = {
         'formatif-blue': '#3939ff',
         'formatif-blue-lighter': '#e7e7ff',
       },
-      height: {
-        '1/10': '10%',
-      },
     },
   },
   plugins: [],


### PR DESCRIPTION
# Description

Replaced depreciated fxLayout library implemented with equivalent Tailwindcss for hero-sidebar component. 

## Type of change

# How Has This Been Tested?

before:
![hero-sidebar-component-no-changes](https://github.com/thoth-tech/doubtfire-web/assets/128195951/900a8ca6-388f-4efa-967c-c0eba7d41ffd)

after:
![hero-sidebar-component-with-tailwind](https://github.com/thoth-tech/doubtfire-web/assets/128195951/6f5730c5-db54-4ad4-99bd-7982ddbc76d6)

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
