### PR TITLE
refactor: replace fxLayout with tailwind equivalent -footer

### DIFF
--- a/src/app/common/footer/footer.component.html
+++ b/src/app/common/footer/footer.component.html
@@ -19,7 +19,7 @@
   }
 
   <div class="flex w-full">
-    <f-user-badge fxFlex fxFlexAlign="start start" [selectedTask]="selectedTask"></f-user-badge>
+    <f-user-badge class="flex-1 self-start" [selectedTask]="selectedTask"></f-user-badge>
 
     <span class="center-buttons flex justify-center">
       <button
@@ -69,7 +69,7 @@
       </button>
     </span>
 
-    <div fxFlex fxFlexAlign="end start" fxLayout="row" fxLayoutAlign="end center">
+    <div class="flex flex-1 flex-row self-end justify-end items-center">
       @if (selectedTask?.similaritiesDetected) {
       <button
         #similaritiesButton


### PR DESCRIPTION
# Description

Replace the deprecated fx-Layout with equivalent Tailwind for footer component.

# How Has This Been Tested?

## Before
<img width="1440" alt="SIT764 enhance:tailwind-footer-migration before" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/c982c9ea-f38d-4e5f-9142-d18bb001cdfb">

## After
<img width="1440" alt="SIT764 enhance:tailwind-footer-migration after" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/b84bcafb-9d4c-4f02-8856-bda719ef5a7b">

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
