### PR TITLE
refactor: replace fx-layout with tailwind equivalent - user-badge

### DIFF
--- a/src/app/common/user-badge/user-badge.component.html
+++ b/src/app/common/user-badge/user-badge.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row" fxLayoutAlign="start start">
+<div class="flex flex-row justify-start items-start">
   <a (click)="!unselected ? goToStudent() : null" style="display: flex">
     <user-icon
       size="40"
@@ -7,7 +7,7 @@
       style="margin-right: 8px"
     ></user-icon>
   </a>
-  <div fxLayout="column" fxLayoutAlign="center start" style="line-height: 0.5em; margin-top: 4px">
+  <div class="flex-col justify-center items-start" style="line-height: 0.5em; margin-top: 4px">
     <div style="margin-top: 6px" id="placeholder1" [hidden]="!unselected"></div>
     <div id="placeholder2" [hidden]="!unselected"></div>
     <a (click)="!unselected ? goToStudent() : null" style="display: flex">


### PR DESCRIPTION
# Description

Replaced the fx-layout usage in the user-badge component with the Tailwind equivalent due to the deprecation of the fx-layout library.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Run the _doubtfire-deploy_ dev container to start the front-end and back-end.
2. Login with the test tutor account (_atutor_).
3. Click on a unit they teach.
4. Click on the dropdown arrow beside the _Search Inbox_ and select _All Students_ in the _Students_ dropdown.
5. Click on a student.
6. The user badge would be on the bottom left of the footer showing the student's profile icon, name, and task name.

## Before

![before-badge](https://github.com/thoth-tech/doubtfire-web/assets/117552851/df2feec5-09c1-447e-a3bd-6d977cc5b7ea)

## After

![after-badge](https://github.com/thoth-tech/doubtfire-web/assets/117552851/f1277f71-c697-41cd-949c-04bd6e615fc7)

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings