### PR TITLE
refactor: replace fxLayout with tailwind equivalent -inbox-comment

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.html
@@ -36,9 +36,9 @@
 >
   @for (emoji of emojiSearchResults; track emoji) {
     <mat-list-item (click)="emojiSelected(emoji.native)">
-      <div fxLayout="row" fxLayoutAlign="start center">
+      <div class="flex flex-row justify-start items-center">
         <ngx-emoji style="align-items: center" [emoji]="emoji" set="apple" size="20"></ngx-emoji>
-        <div class="emoji-details" fxLayout="column" fxLayoutAlign="center start">
+        <div class="emoji-details flex-col justify-center items-start">
           <div style="font-weight: 500; font-size: 12px">{{ emoji.name }}</div>
           <div style="font-size: 10px">{{ emoji.colons }}</div>
         </div>
@@ -54,10 +54,10 @@
   ng-submit="addComment()"
   role="form"
 >
-  <div fxLayout="row" fxLayoutAlign="space-around center" class="composer-container">
+  <div class="flex flex-row justify-around items-center composer-container">
     <div class="composer-action-group" [@shrinkgrow]="$userIsTyping | async">
       <!-- if active -->
-      <div fxLayout="row" fxLayoutAlign="start center">
+      <div class="flex flex-row justify-start items-center">
         @if ($userIsTyping | async) {
           <button
             (click)="$userIsTyping.next(false); recording = false"


### PR DESCRIPTION
# Description

Replace the deprecated fx-Layout with equivalent Tailwind for inbox comment component.

# How Has This Been Tested?

The inbox comment component is where teachers and students can exchange some feedback, discussions, answers and questions regarding to the submission tasks. When clicking in a specific task of unit/student account, inbox comment component is located in the right hand side of the website. It contains features such as Expand action buttons, Create a Real Talk discussion, Attach a file, Send a recording and Choose an emoji. 

## Before:

<img width="382" alt="SIT764 tailwind migration inbox-comment (before)" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/89be5f6e-11bc-4930-a6d1-be98864347ff">

## After:

<img width="388" alt="SIT764 tailwind migration inbox-comment (after)" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/a2d5f49e-a05b-41f7-bef5-032b935d03c1">

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
