### PR TITLE
refactor: replace fxLayout with tailwind equivalent -staff-task-list

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -85,8 +85,8 @@
       >
         <form class="search-options">
           <div class="task-definition">
-            <div fxLayout="row" fxLayoutAlign="space-between center">
-              <mat-form-field fxFlex>
+            <div class="flex flex-row justify-between items-center">
+              <mat-form-field class="flex-1">
                 <mat-label>Task</mat-label>
                 <mat-select
                   [(ngModel)]="filters.taskDefinitionIdSelected"
@@ -112,8 +112,8 @@
             </div>
           </div>
           <!--/task-definition-->
-          <div fxLayout="row" fxLayoutAlign="space-between center">
-            <mat-form-field fxFlex>
+          <div class="flex flex-row justify-between items-center">
+            <mat-form-field class="flex-1">
               <mat-label>Students</mat-label>
               <mat-select
                 [(ngModel)]="filters.tutorialIdSelected"
@@ -147,7 +147,7 @@
 </ng-template>
 
 <!-- Actual task-inbox -->
-<div class="task-inbox" [ngClass]="isNarrow ? 'narrow-width' : 'full-width'" div fxLayout="column" fxLayoutAlign="none">
+<div class="task-inbox flex flex-col justify-normal" [ngClass]="isNarrow ? 'narrow-width' : 'full-width'">
   <div class="openSearchDialog" [hidden]="!isNarrow">
     <button mat-icon-button (click)="openDialog()" aria-label="Seach Button">
       <mat-icon>search</mat-icon>
@@ -200,8 +200,8 @@
                 similarities: task.similaritiesDetected
               }"
             ></span>
-            <user-icon fxFlexAlign="center" [user]="task.project.student" [size]="30"> </user-icon>
-            <div class="task-list-data truncate" fxFlex [hidden]="isNarrow">
+            <user-icon class="self-center" [user]="task.project.student" [size]="30"> </user-icon>
+            <div class="task-list-data truncate flex-1" [hidden]="isNarrow">
               <h4 class="student-name">{{ task.project.student.name }}</h4>
               <div class="task-details truncate">
                 {{ task.definition.abbreviation }} -


### PR DESCRIPTION
# Description

Replace the deprecated fx-Layout with equivalent Tailwind for staff task list component.

# How Has This Been Tested?

- First, users log in with staff account and select a teaching unit.
- There is a webpage with search boxes where users can filter tasks, classes, etc.
- By clicking at a specific student name, the task submission file is displayed in the main view, with inbox comment section is aside.

## Before:

<img width="1440" alt="SIT764 tailwind migration staff-task-list (before)" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/d251eb83-2954-4bf1-a421-4adeb75a7a26">

## After:

<img width="1440" alt="SIT764 tailwind migration staff-task-list (after)" src="https://github.com/thoth-tech/doubtfire-web/assets/140044678/e0e79bfd-3ec7-428b-8a0e-74b2ad20e2a6">

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
