### PR TITLE
refactor(migration): replaced fx-layout with tailwind equivalent - sign-in component

### DIFF
--- a/src/app/sessions/states/sign-in/sign-in.component.html
+++ b/src/app/sessions/states/sign-in/sign-in.component.html
@@ -1,30 +1,28 @@
 <!--Draft-->
-<section class="welcome" fxFlex fxLayout="row">
-  <f-hero-sidebar fxHide.lt-md fxFlexAlign="start"></f-hero-sidebar>
-  <section class="content" fxFlex.gt-sm [ngClass.gt-sm]="'large'" fxLayout.gt-sm="column">
+<section class="welcome flex flex-row h-screen">
+  <f-hero-sidebar class="media-screen-hide flex-col h-full"></f-hero-sidebar>
+  <section class="content flex flex-col justify-start items-center h-screen">
     <div class="container">
       <div class="subcontainer">
-        <div class="wordmark" fxLayout="row" fxLayoutAlign="start center" fxHide.gt-sm fxFlexAlign="start">
+        <div class="wordmark items-center">
           <img src="../../../assets/images/logo-bw.svg" width="40px" alt="Homepage Logo" />
           <p>{{ externalName.value }}</p>
         </div>
-        <h1 class="welcome-heading" fxFlexAlign="start">Welcome to {{ externalName.value }}</h1>
+        <h1 class="welcome-heading">Welcome to {{ externalName.value }}</h1>
         <form
           #form="ngForm"
           (ngSubmit)="signIn({ username: formData.username, password: formData.password })"
-          fxLayout="column"
-          fxLayoutAlign="center start"
-          class="sign-in-form"
+          class="sign-in-form flex flex-col items-center md:items-start"
         >
           @if (showCredentials) {
-<mat-form-field appearance="outline" fxFlex fxFlexFill>
+<mat-form-field appearance="outline" class="flex flex-fill w-full">
             <mat-label>Username</mat-label>
             <input matInput name="username" required [(ngModel)]="formData.username" />
           </mat-form-field>
 }
 
           @if (showCredentials) {
-<mat-form-field appearance="outline" fxFlex fxFlexFill>
+<mat-form-field appearance="outline" class="flex flex-fill w-full">
             <mat-label>Password</mat-label>
             <input type="password" matInput name="password" required [(ngModel)]="formData.password" />
           </mat-form-field>

--- a/src/app/sessions/states/sign-in/sign-in.component.html
+++ b/src/app/sessions/states/sign-in/sign-in.component.html
@@ -1,3 +1,4 @@
+<!--Draft-->
 <section class="welcome" fxFlex fxLayout="row">
   <f-hero-sidebar fxHide.lt-md fxFlexAlign="start"></f-hero-sidebar>
   <section class="content" fxFlex.gt-sm [ngClass.gt-sm]="'large'" fxLayout.gt-sm="column">

--- a/src/styles/common/hero-sidebar-layout.scss
+++ b/src/styles/common/hero-sidebar-layout.scss
@@ -36,6 +36,7 @@ h1 {
 }
 
 .wordmark {
+  display: none;
   p {
     margin: 0;
     padding: 0;
@@ -48,6 +49,12 @@ h1 {
   }
 }
 
+@media screen and (max-width: 768px) {
+  .wordmark {
+    display: flex; /* Show on small screens */
+  }
+}
+
 f-sign-in .container,
 f-welcome .container {
   max-width: 416px;
@@ -57,4 +64,15 @@ f-welcome .container {
 
 .welcome {
   width: 100%;
+}
+
+.media-screen-hide {
+  display: block; /* Initially visible */
+}
+
+/* Media query for small screens */
+@media screen and (max-width: 768px) {
+  .media-screen-hide {
+    display: none; /* Hide on small screens */
+  }
 }


### PR DESCRIPTION
# Description
Replaced fx-layout with tailwind equivalent in sign-in-component. 

# Before

![image](https://github.com/thoth-tech/doubtfire-web/assets/88503893/59faa2b7-604b-4d91-9e06-e239a974e679)

# After

![image](https://github.com/thoth-tech/doubtfire-web/assets/88503893/fbcd6ee2-5e76-4a03-8a84-1bbc5cda088e)