### PR TITLE
refactor : Replace fx-layout with tailwind equivalent - discussion-prompt-composer

### DIFF
--- a/src/app/tasks/task-comment-composer/discussion-prompt-composer/discussion-prompt-composer.component.html
+++ b/src/app/tasks/task-comment-composer/discussion-prompt-composer/discussion-prompt-composer.component.html
@@ -1,17 +1,20 @@
+<!-- Import Tailwind CSS -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
+
 <h4>Step 1. Record and add up to 3 prompts.</h4>
-<div [hidden]="!canRecord || isSending" fxLayout="row" fxLayoutAlign="space-around center">
+<div [hidden]="!canRecord || isSending" class="flex justify-around items-center">
   <div>
     <button mat-icon-button aria-label="Record icon button" [disabled]="!canAddRecording" id='btnRecordPrompt'
       (click)="recordingToggle()" mat-icon-button aria-label="Record audio prompt">
-      <mat-icon [hidden]="!isRecording">stop_rounded</mat-icon>
-      <mat-icon [hidden]="isRecording">fiber_manual_record</mat-icon>
+      <span *ngIf="isRecording" class="material-icons">stop_rounded</span>
+      <span *ngIf="!isRecording" class="material-icons">fiber_manual_record</span>
     </button>
   </div>
 
   <div class="audio-recorder">
-    <p [hidden]="canRecord">Audio recording <br> only supported in modern versions of Chrome, Firefox and Safari.</p>
+    <p [hidden]="canRecord" class="text-center">Audio recording <br> only supported in modern versions of Chrome, Firefox and Safari.</p>
     <mat-spinner class="send-audio-spinner" [diameter]="72" [strokeWidth]="2" [hidden]="!isSending"></mat-spinner>
-    <div fxLayout="row" fxLayoutAlign="center center">
+    <div class="flex justify-center items-center">
       <canvas #discussionPromptComposerCanvas class="discussion-prompt-audio-visualiser"></canvas>
     </div>
     <audio #discussionPromptComposerAudio></audio>
@@ -28,21 +31,21 @@
 <h4>Step 2. Optionally play back prompts.</h4>
 <mat-action-list id="recordingList">
   <h3 mat-subheader>Discussion Prompts</h3>
-  @for (recording of recordings; track recording; let i = $index) {
-  <button mat-list-item (click)="playRecording(getUrl(recording))">
-    <mat-icon mat-list-icon>play_arrow_rounded</mat-icon>
-    <h4 mat-line>Prompt {{i + 1}}</h4>
-    <p mat-line> Click to play recording </p>
-  </button>
-}
+  <ng-container *ngFor="let recording of recordings; let i = index">
+    <button mat-list-item (click)="playRecording(getUrl(recording))">
+      <mat-icon mat-list-icon>play_arrow_rounded</mat-icon>
+      <h4 mat-line>Prompt {{ i + 1 }}</h4>
+      <p mat-line> Click to play recording </p>
+    </button>
+  </ng-container>
 </mat-action-list>
 
 <h4>Step 3. Send.</h4>
-<div fxLayout="row" fxLayoutAlign="end center">
+<div class="flex justify-end items-center">
   <button mat-raised-button color="primary" type="button" mat-dialog-close
     (click)="sendRecording()" [hidden]="recordings.length === 0">
     Send
   </button>
 </div>
 
-<mat-divider style="margin: 3em 0 3em 0;"></mat-divider>
+<mat-divider class="my-12"></mat-divider>


### PR DESCRIPTION

# Description

Key points to note:

- I replaced fxLayout and fxLayoutAlign with Tailwind CSS utility classes for flexible layout.
- Applied Tailwind CSS classes for text alignment and margin.
- Used *ngFor for better readability in the loop.
- Added a Tailwind CSS divider (my-12 for vertical margin) for visual separation.


## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request


Before Output :

![x](https://github.com/thoth-tech/doubtfire-web/assets/118825420/38af789b-0f40-4a97-b02b-55b4021e0e01)

After Output : 

![xx](https://github.com/thoth-tech/doubtfire-web/assets/118825420/28f9a88b-2b09-46c0-8712-9e5c38ed1afc)
