### PR TITLE
refactor: replace fxLayout with tailwind equivalents - intelligent-discussion-dialog

### DIFF
--- a/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-dialog.html
+++ b/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-dialog.html
@@ -5,45 +5,69 @@
   <mat-step>
     <ng-template matStepLabel>Introduction</ng-template>
     <div class="introduction-text">
-      <img id="discussion-splash-image" src="/assets/images/discussion_splash_1.svg" alt="Discussion Splash Image">
+      <img
+        id="discussion-splash-image"
+        src="/assets/images/discussion_splash_1.svg"
+        alt="Discussion Splash Image"
+      />
       <p>
-        Your tutor would like to discuss some topics with you regarding this task
+        Your tutor would like to discuss some topics with you regarding this task Discussions are a
+        great way for you and your tutor to gauge your understanding of concepts and are an
+        important aspect of your portfolio. These discussions are designed to be casual and
+        informal, and will <strong>require a working microphone and speakers.</strong>
 
-        Discussions are a great way for you and your tutor to gauge your understanding of concepts and are an important
-        aspect of your portfolio.
-
-        These discussions are designed to be casual and informal, and will <strong>require a working microphone and
-          speakers.</strong>
-
-        These are timed discussions, <strong> you will have a few minutes from when you hear your tutor's discussion
-          prompt to reply.</strong> <br><br><br><br>
+        These are timed discussions,
+        <strong>
+          you will have a few minutes from when you hear your tutor's discussion prompt to
+          reply.</strong
+        >
+        <br /><br /><br /><br />
 
         You should only proceed once you are in a suitably quiet environment.
       </p>
-
     </div>
     <div>
-      <button mat-button mat-raised-button matStepperNext color="primary" style="float: right;">Next</button>
+      <button mat-button mat-raised-button matStepperNext color="primary" style="float: right">
+        Next
+      </button>
     </div>
   </mat-step>
 
   <mat-step [completed]="confirmed">
     <ng-template matStepLabel>Test everything is working</ng-template>
     <microphone-tester #testRecorder></microphone-tester>
-    <button mat-button mat-raised-button matStepperNext color="primary" matStepperPrevious>Back</button>
+    <button mat-button mat-raised-button matStepperNext color="primary" matStepperPrevious>
+      Back
+    </button>
     <div style="float: right">
-      <mat-checkbox style="margin-right: 20px;" [(ngModel)]="confirmed" matStepperNext required> Ready to go!
+      <mat-checkbox style="margin-right: 20px" [(ngModel)]="confirmed" matStepperNext required>
+        Ready to go!
       </mat-checkbox>
-      <button [disabled]="!confirmed" (click)="disableTester()" mat-button mat-raised-button matStepperNext
-        color="primary" matStepperNext>Next</button>
+      <button
+        [disabled]="!confirmed"
+        (click)="disableTester()"
+        mat-button
+        mat-raised-button
+        matStepperNext
+        color="primary"
+        matStepperNext
+      >
+        Next
+      </button>
     </div>
   </mat-step>
 
   <mat-step>
     <ng-template matStepLabel>Discussion</ng-template>
-    <div id="discussionRecorderContainer" class="flex flex-row content-center justify-around items-center">
-
-      <intelligent-discussion-recorder [task]="data.task" [discussion]="data.dc" #discussionRecorder>
+    <div
+      id="discussionRecorderContainer"
+      class="flex flex-row content-center justify-around items-center"
+    >
+      <intelligent-discussion-recorder
+        [task]="data.task"
+        [discussion]="data.dc"
+        #discussionRecorder
+      >
       </intelligent-discussion-recorder>
       <div class="flex flex-col content-end justify-start items-end">
         <p id="discussionCountdown">{{guide.text}}</p>
@@ -51,20 +75,51 @@
       </div>
     </div>
     <mat-divider></mat-divider>
-    <button style="margin-bottom: 3em" mat-button mat-stroked-button [hidden]="startedDiscussion" (click)="startDiscussion()">Start
-      discussion</button>
+    <button
+      style="margin-bottom: 3em"
+      mat-button
+      mat-stroked-button
+      [hidden]="startedDiscussion"
+      (click)="startDiscussion()"
+    >
+      Start discussion
+    </button>
     <div class="flex flex-row content-center justify-evenly items-center" [hidden]="!inDiscussion">
       <h2 class="mat-headline-5">Prompt {{activePromptId+1}} of {{numberOfPrompts}}</h2>
-      <button style="margin-bottom: 3em;" [hidden]="activePromptId === numberOfPrompts " mat-button mat-stroked-button
-        (click)="responseConfirmed($event)">{{activePromptId+1 === numberOfPrompts ? 'Finish' : 'Next Prompt' }}
+      <button
+        style="margin-bottom: 3em"
+        [hidden]="activePromptId === numberOfPrompts "
+        mat-button
+        mat-stroked-button
+        (click)="responseConfirmed($event)"
+      >
+        {{activePromptId+1 === numberOfPrompts ? 'Finish' : 'Next Prompt' }}
       </button>
     </div>
 
     <div>
-      <button [disabled]="!discussionComplete" mat-button mat-raised-button matStepperNext color="primary"
-        matStepperNext required style="float: right;">Complete</button>
-      <button [disabled]="startedDiscussion" mat-button mat-raised-button matStepperNext color="primary"
-        matStepperPrevious>Back</button>
+      <button
+        [disabled]="!discussionComplete"
+        mat-button
+        mat-raised-button
+        matStepperNext
+        color="primary"
+        matStepperNext
+        required
+        style="float: right"
+      >
+        Complete
+      </button>
+      <button
+        [disabled]="startedDiscussion"
+        mat-button
+        mat-raised-button
+        matStepperNext
+        color="primary"
+        matStepperPrevious
+      >
+        Back
+      </button>
     </div>
   </mat-step>
 

--- a/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-dialog.html
+++ b/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-dialog.html
@@ -41,11 +41,11 @@
 
   <mat-step>
     <ng-template matStepLabel>Discussion</ng-template>
-    <div fxLayout="row" fxLayoutAlign="space-around center" id="discussionRecorderContainer">
+    <div id="discussionRecorderContainer" class="flex flex-row content-center justify-around items-center">
 
       <intelligent-discussion-recorder [task]="data.task" [discussion]="data.dc" #discussionRecorder>
       </intelligent-discussion-recorder>
-      <div fxLayout="column" fxLayoutAlign="start end">
+      <div class="flex flex-col content-end justify-start items-end">
         <p id="discussionCountdown">{{guide.text}}</p>
         <!-- <p>remaining</p> -->
       </div>
@@ -53,7 +53,7 @@
     <mat-divider></mat-divider>
     <button style="margin-bottom: 3em" mat-button mat-stroked-button [hidden]="startedDiscussion" (click)="startDiscussion()">Start
       discussion</button>
-    <div fxLayout="row" fxLayoutAlign="space-evenly center" [hidden]="!inDiscussion">
+    <div class="flex flex-row content-center justify-evenly items-center" [hidden]="!inDiscussion">
       <h2 class="mat-headline-5">Prompt {{activePromptId+1}} of {{numberOfPrompts}}</h2>
       <button style="margin-bottom: 3em;" [hidden]="activePromptId === numberOfPrompts " mat-button mat-stroked-button
         (click)="responseConfirmed($event)">{{activePromptId+1 === numberOfPrompts ? 'Finish' : 'Next Prompt' }}


### PR DESCRIPTION
# Description

Replaced depreciated fxLayout library implemented with equivalent Tailwindcss for intelligent-discussion-dialog component component. 

**before**
![intelligent-discussion-dialog-first-no-changes](https://github.com/thoth-tech/doubtfire-web/assets/128195951/8f4162b7-a79f-479d-9b99-567c4194d268)
![intelligent-discussion-dialog-second-no-changes](https://github.com/thoth-tech/doubtfire-web/assets/128195951/aff62bdb-8234-48ba-a40e-28cedb44a647)

**after**
![intelligent-discussion-dialog-first-tailwind](https://github.com/thoth-tech/doubtfire-web/assets/128195951/9921782b-3ba3-4a5b-a76a-a8319a3888ec)
![intelligent-discussion-dialog-second-tailwind](https://github.com/thoth-tech/doubtfire-web/assets/128195951/9fcceb3a-c7bc-4d0e-8355-28b2ad2d6620)

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings