### PR TITLE
refactor: replace fxLayout with tailwind equivalent - extension comment composer

### DIFF
--- a/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.html
+++ b/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.html
@@ -1,27 +1,32 @@
-<div fxLayout="row" fxLayoutAlign="space-evenly center">
+<div class="flex justify-around items-center">
   @if (comment.assessed) {
-<div fxLayout="column" fxLayoutAlign="space-around center">
-    <hr class="hr-text" [attr.data-content]="message" />
-    <p class="fade-text"><strong> reason:</strong> {{ comment.text }}</p>
-  </div>
-}
+    <div class="flex flex-col justify-around items-center">
+      <hr class="hr-text" [attr.data-content]="message" />
+      <p class="fade-text"><strong> reason:</strong> {{ comment.text }}</p>
+    </div>
+  }
 
   @if (!comment.assessed) {
-<div fxLayout="column" fxLayoutAlign="space-around center">
-    <hr class="hr-fade" />
-    <p>
-      {{ message }} <br />
-      <strong> reason:</strong> {{ comment.text }}
-    </p>
-    @if (isNotStudent) {
-<div fxLayout="row" fxLayoutAlign="space-evenly center">
-      <button (click)="grantExtension()" mat-flat-button color="primary" style="background-color: #43a047">
-        Grant
-      </button>
-      <button (click)="denyExtension()" mat-flat-button color="warn">Deny</button>
+    <div class="flex flex-col justify-around items-center">
+      <hr class="hr-fade" />
+      <p>
+        {{ message }} <br />
+        <strong> reason:</strong> {{ comment.text }}
+      </p>
+      @if (isNotStudent) {
+        <div class="flex justify-around items-center">
+          <button
+            (click)="grantExtension()"
+            mat-flat-button
+            color="primary"
+            style="background-color: #43a047"
+          >
+            Grant
+          </button>
+          <button (click)="denyExtension()" mat-flat-button color="warn">Deny</button>
+        </div>
+      }
+      <hr class="hr-fade" />
     </div>
-}
-    <hr class="hr-fade" />
-  </div>
-}
+  }
 </div>

--- a/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.scss
+++ b/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.scss
@@ -1,5 +1,8 @@
 div {
   width: 100%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
 }
 
 p {
@@ -45,10 +48,8 @@ hr {
     position: relative;
     display: inline-block;
     color: black;
-
     padding: 0 0.5em;
     line-height: 1.5em;
-
     color: #9696969d;
     background-color: #fff;
   }

--- a/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.scss
+++ b/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.scss
@@ -1,8 +1,5 @@
 div {
   width: 100%;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
 }
 
 p {


### PR DESCRIPTION
Update extension-comment.component.html from fx-layout to tailwind equivalent



Before:
![before1](https://github.com/thoth-tech/doubtfire-web/assets/132536077/3ae75e35-ee96-42d8-b33a-041cc0a91655)


After: 
![after1](https://github.com/thoth-tech/doubtfire-web/assets/132536077/bf5d9872-ac42-4505-bf9f-5e95d007d283)


Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update
How Has This Been Tested?
Simply visiting the specific page in the testing environment (tutor Assessment comment) and checked the old code to see if it worked, followed by testing the updated code. Both appeared identical.

Testing Checklist:
[ ✓] Tested in latest Chrome
[ ✓] Tested in latest Safari
[ ✓] Tested in latest Firefox
Checklist:
[ ✓] My code follows the style guidelines of this project
[ ✓] I have performed a self-review of my own code
[ ✓] I have made corresponding changes to the documentation
[ ✓] My changes generate no new warnings