### PR TITLE
Adjust Unit Chair admin page to allow upload of numbas test

### DIFF
--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -31,6 +31,7 @@ export class TaskDefinition extends Entity {
   groupSet: GroupSet = null;
   hasTaskSheet: boolean;
   hasTaskResources: boolean;
+  hasNumbasTest: boolean;
   hasTaskAssessmentResources: boolean;
   isGraded: boolean;
   maxQualityPts: number;
@@ -150,6 +151,13 @@ export class TaskDefinition extends Entity {
     }`;
   }
 
+  public getNumbasTestUrl(asAttachment: boolean = false) {
+    const constants = AppInjector.get(DoubtfireConstants);
+    return `${constants.API_URL}/units/${this.unit.id}/task_definitions/${this.id}/numbas_test.json${
+      asAttachment ? '?as_attachment=true' : ''
+    }`;
+  }
+
   public get targetGradeText(): string {
     return Grade.GRADES[this.targetGrade];
   }
@@ -174,6 +182,12 @@ export class TaskDefinition extends Entity {
     }/task_resources`;
   }
 
+  public get numbasTestUploadUrl(): string {
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/units/${this.unit.id}/task_definitions/${
+      this.id
+    }/numbas_test`;
+  }
+
   public get taskAssessmentResourcesUploadUrl(): string {
     return `${AppInjector.get(DoubtfireConstants).API_URL}/units/${this.unit.id}/task_definitions/${
       this.id
@@ -194,6 +208,11 @@ export class TaskDefinition extends Entity {
   public deleteTaskResources(): Observable<any> {
     const httpClient = AppInjector.get(HttpClient);
     return httpClient.delete(this.taskResourcesUploadUrl).pipe(tap(() => (this.hasTaskResources = false)));
+  }
+
+  public deleteNumbasTest(): Observable<any> {
+    const httpClient = AppInjector.get(HttpClient);
+    return httpClient.delete(this.numbasTestUploadUrl).pipe(tap(() => (this.hasNumbasTest = false)));
   }
 
   public deleteTaskAssessmentResources(): Observable<any> {

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -31,7 +31,12 @@ export class TaskDefinition extends Entity {
   groupSet: GroupSet = null;
   hasTaskSheet: boolean;
   hasTaskResources: boolean;
-  hasNumbasTest: boolean;
+  hasEnabledNumbasTest: boolean;
+  hasUploadedNumbasTest: boolean;
+  hasUnlimitedRetriesForNumbas: boolean;
+  hasTimeDelayForNumbas: boolean;
+  isNumbasRestrictedTo1Attempt: boolean;
+  numbasTimeDelay: string = 'no delay';
   hasTaskAssessmentResources: boolean;
   isGraded: boolean;
   maxQualityPts: number;
@@ -212,7 +217,7 @@ export class TaskDefinition extends Entity {
 
   public deleteNumbasTest(): Observable<any> {
     const httpClient = AppInjector.get(HttpClient);
-    return httpClient.delete(this.numbasTestUploadUrl).pipe(tap(() => (this.hasNumbasTest = false)));
+    return httpClient.delete(this.numbasTestUploadUrl).pipe(tap(() => (this.hasUploadedNumbasTest = false)));
   }
 
   public deleteTaskAssessmentResources(): Observable<any> {

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -205,6 +205,7 @@ import { TaskDefinitionUploadComponent } from './units/states/edit/directives/un
 import { TaskDefinitionOptionsComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-options/task-definition-options.component';
 import { TaskDefinitionResourcesComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-resources/task-definition-resources.component';
 import { TaskDefinitionOverseerComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-overseer/task-definition-overseer.component';
+import { TaskDefinitionNumbasComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component';
 import { UnitAnalyticsComponent } from './units/states/analytics/unit-analytics-route.component';
 import { FileDropComponent } from './common/file-drop/file-drop.component';
 import { UnitTaskEditorComponent } from './units/states/edit/directives/unit-tasks-editor/unit-task-editor.component';
@@ -266,6 +267,7 @@ import { TasksViewerComponent } from './units/states/tasks/tasks-viewer/tasks-vi
     TaskDefinitionOptionsComponent,
     TaskDefinitionResourcesComponent,
     TaskDefinitionOverseerComponent,
+    TaskDefinitionNumbasComponent,
     UnitAnalyticsComponent,
     StudentTutorialSelectComponent,
     StudentCampusSelectComponent,

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
@@ -62,10 +62,10 @@
   </div>
 
   <div class="w-full">
-    <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Upload requirements</h3>
-    <p class="font-normal text-gray-700">What do students need to upload?</p>
+    <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Task description and resources</h3>
+    <p class="font-normal text-gray-700">Upload task descriptions and resources</p>
     <div class="bg-white border border-gray-200 rounded-xl shadow p-6">
-      <f-task-definition-upload [taskDefinition]="taskDefinition"></f-task-definition-upload>
+      <f-task-definition-resources [taskDefinition]="taskDefinition"></f-task-definition-resources>
     </div>
   </div>
 </div>
@@ -80,10 +80,10 @@
   </div>
 
   <div class="w-full">
-    <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Task description and resources</h3>
-    <p class="font-normal text-gray-700">Upload task descriptions and resources</p>
+    <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Upload Numbas test</h3>
+    <p class="font-normal text-gray-700">Upload the corresponding Numbas test</p>
     <div class="bg-white border border-gray-200 rounded-xl shadow p-6">
-      <f-task-definition-resources [taskDefinition]="taskDefinition"></f-task-definition-resources>
+      <f-task-definition-numbas [taskDefinition]="taskDefinition"></f-task-definition-numbas>
     </div>
   </div>
 </div>
@@ -94,6 +94,24 @@
       class="font-bold text-formatif-blue text-3xl rounded-full bg-formatif-blue-lighter flex items-center justify-center w-16 h-16"
     >
       6
+    </div>
+  </div>
+
+  <div class="w-full">
+    <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Upload requirements</h3>
+    <p class="font-normal text-gray-700">What do students need to upload?</p>
+    <div class="bg-white border border-gray-200 rounded-xl shadow p-6">
+      <f-task-definition-upload [taskDefinition]="taskDefinition"></f-task-definition-upload>
+    </div>
+  </div>
+</div>
+
+<div class="flex mt-10">
+  <div class="mr-6">
+    <div
+      class="font-bold text-formatif-blue text-3xl rounded-full bg-formatif-blue-lighter flex items-center justify-center w-16 h-16"
+    >
+      7
     </div>
   </div>
 
@@ -111,7 +129,7 @@
     <div
       class="font-bold text-formatif-blue text-3xl rounded-full bg-formatif-blue-lighter flex items-center justify-center w-16 h-16"
     >
-      7
+      8
     </div>
   </div>
 

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
@@ -1,18 +1,44 @@
-<div class="basis-1/2 flex flex-col">
-  <f-file-drop
-    mode="event"
-    (filesDropped)="uploadNumbasTest($event)"
-    accept="application/zip"
-    [desiredFileName]="'Numbas zip'"
-  />
-  @if (taskDefinition.hasNumbasTest) {
-    <div class="flex flex-row gap-4 pt-4">
-      <button mat-flat-button color="warn" (click)="removeNumbasTest()" class="flex-grow me-4">
-        Delete Numbas Zip
-      </button>
-      <button mat-flat-button color="accent" (click)="downloadNumbasTest()" class="flex-grow ms-4">
-        Download Numbas Zip
-      </button>
-    </div>
+<div class="flex flex-col gap-4">
+  <mat-checkbox matInput required [(ngModel)]="taskDefinition.hasEnabledNumbasTest">
+    Enable Numbas Test
+  </mat-checkbox>
+
+  <div class="basis-1/2 flex flex-col">
+    <f-file-drop
+      mode="event"
+      (filesDropped)="uploadNumbasTest($event)"
+      accept="application/zip"
+      [desiredFileName]="'Numbas zip'"
+    />
+    @if (taskDefinition.hasUploadedNumbasTest) {
+      <div class="flex flex-row gap-4 pt-4">
+        <button mat-flat-button color="warn" (click)="removeNumbasTest()" class="flex-grow me-4">
+          Delete Numbas Zip
+        </button>
+        <button mat-flat-button color="accent" (click)="downloadNumbasTest()" class="flex-grow ms-4">
+          Download Numbas Zip
+        </button>
+      </div>
+    }
+  </div>
+
+  <div class="flex flex-row items-center">
+    <span> Select test rules: </span>
+    <mat-checkbox matInput [(ngModel)]="taskDefinition.hasUnlimitedRetriesForNumbas">Unlimited retries</mat-checkbox>
+    <mat-checkbox matInput [(ngModel)]="taskDefinition.hasTimeDelayForNumbas">Time delay</mat-checkbox>
+    <mat-checkbox matInput [(ngModel)]="taskDefinition.isNumbasRestrictedTo1Attempt">Restrict to 1 attempt</mat-checkbox>
+  </div>
+
+  @if (taskDefinition.hasTimeDelayForNumbas) {
+    <mat-form-field appearance="outline">
+      <mat-label>Time delay</mat-label>
+      <mat-select [(ngModel)]="taskDefinition.numbasTimeDelay">
+        <mat-option value="no delay">No delay</mat-option>
+        <mat-option value="30 min">30 min</mat-option>
+        <mat-option value="2 hours">2 hours</mat-option>
+        <mat-option value="1 day">1 day</mat-option>
+        <mat-option value="see tutor">See tutor</mat-option>
+      </mat-select>
+    </mat-form-field>
   }
 </div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
@@ -1,0 +1,18 @@
+<div class="basis-1/2 flex flex-col">
+  <f-file-drop
+    mode="event"
+    (filesDropped)="uploadNumbasTest($event)"
+    accept="application/zip"
+    [desiredFileName]="'Numbas zip'"
+  />
+  @if (taskDefinition.hasNumbasTest) {
+    <div class="flex flex-row gap-4 pt-4">
+      <button mat-flat-button color="warn" (click)="removeNumbasTest()" class="flex-grow me-4">
+        Delete Numbas Zip
+      </button>
+      <button mat-flat-button color="accent" (click)="downloadNumbasTest()" class="flex-grow ms-4">
+        Download Numbas Zip
+      </button>
+    </div>
+  }
+</div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
@@ -43,7 +43,7 @@ export class TaskDefinitionNumbasComponent {
       const file = validFiles[0];
       // Temporary until Numbas backend is fixed: save uploaded file to local Downloads folder
       this.saveZipFile(file);
-      this.taskDefinition.hasNumbasTest = true;
+      this.taskDefinition.hasUploadedNumbasTest = true;
       // this.taskDefinitionService.uploadNumbasTest(this.taskDefinition, file).subscribe({
       //   next: () => this.alerts.add('success', 'Uploaded Numbas test', 2000),
       //   error: (message) => this.alerts.add('danger', message, 6000),

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
@@ -1,0 +1,69 @@
+import { Component, Inject, Input } from '@angular/core';
+import { alertService } from 'src/app/ajs-upgraded-providers';
+import { TaskDefinition } from 'src/app/api/models/task-definition';
+import { Unit } from 'src/app/api/models/unit';
+import { TaskDefinitionService } from 'src/app/api/services/task-definition.service';
+import { FileDownloaderService } from 'src/app/common/file-downloader/file-downloader.service';
+
+@Component({
+  selector: 'f-task-definition-numbas',
+  templateUrl: 'task-definition-numbas.component.html',
+  styleUrls: ['task-definition-numbas.component.scss'],
+})
+export class TaskDefinitionNumbasComponent {
+  @Input() taskDefinition: TaskDefinition;
+
+  constructor(
+    private fileDownloaderService: FileDownloaderService,
+    @Inject(alertService) private alerts: any,
+    private taskDefinitionService: TaskDefinitionService
+  ) {}
+
+  public get unit(): Unit {
+    return this.taskDefinition?.unit;
+  }
+
+  public downloadNumbasTest() {
+    this.fileDownloaderService.downloadFile(
+      this.taskDefinition.getNumbasTestUrl(true),
+      this.taskDefinition.name + '-Numbas.zip',
+    );
+  }
+
+  public removeNumbasTest() {
+    this.taskDefinition.deleteNumbasTest().subscribe({
+      next: () => this.alerts.add('success', 'Deleted Numbas test', 2000),
+      error: (message) => this.alerts.add('danger', message, 6000),
+    });
+  }
+
+  public uploadNumbasTest(files: FileList) {
+    const validFiles = Array.from(files as ArrayLike<File>).filter((f) => f.type === 'application/zip');
+    if (validFiles.length > 0) {
+      const file = validFiles[0];
+      // Temporary until Numbas backend is fixed: save uploaded file to local Downloads folder
+      this.saveZipFile(file);
+      this.taskDefinition.hasNumbasTest = true;
+      // this.taskDefinitionService.uploadNumbasTest(this.taskDefinition, file).subscribe({
+      //   next: () => this.alerts.add('success', 'Uploaded Numbas test', 2000),
+      //   error: (message) => this.alerts.add('danger', message, 6000),
+      // });
+    } else {
+      this.alerts.add('danger', 'Please drop a ZIP to upload for this task', 6000);
+    }
+  }
+
+  private saveZipFile(zipData) {
+    const blob = new Blob([zipData], {type: 'application/zip'});
+
+    // Create an anchor element and set its href to the blob URL
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'numbas.zip';
+
+    // Append the link to the document, trigger the download, then remove the link
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+}


### PR DESCRIPTION
# Description

Adjusted Unit Chair admin page to enable Numbas testing through uploading a Numbas test ZIP file for the task and choosing test rules. The already existing options have been rearranged according to instructions by Daniel.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Login as `aconvenor` and click on the shield icon beside profile on top right to Manage Units.
2. Click on a unit and go to the Tasks tab.
3. Add task or select a task and scroll down to the Numbas section.
4. Choose a ZIP file and click on the upload icon.
5. The ZIP file currently will save to the local Downloads folder and update the view to include the delete and download button. Once the backend is updated to save Numbas files, this will be updated to communicate with the backend.

## Before

![Screenshot 2024-03-05 at 11 54 20 pm](https://github.com/thoth-tech/doubtfire-web/assets/117552851/99203434-17e5-4ef7-9147-5a42fb347393)

## After

![Screenshot 2024-03-07 at 3 54 39 pm](https://github.com/thoth-tech/doubtfire-web/assets/117552851/17c9255f-96df-4426-b58f-d50cdadd921f)

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings