### PR TITLE
fix: add the correct enterkeyhint to the comment composer

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.html
@@ -154,6 +154,7 @@
         (keydown)="keyTyped()"
         placeholder="Aa"
         name="commentComposer"
+        enterkeyhint="send"
       ></div>
       @if (recording) {
         <audio-comment-recorder


### PR DESCRIPTION
# Description

Was trying to reproduce https://github.com/doubtfire-lms/doubtfire-web/issues/705 and turns out it's already fixed in development. Only remaining thing to address was enterkeyhint, which makes enter buttons on mobile devices display the correct icon or text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested sending messages and making sure the enter key has the correct icon/text on iOS 17.3.1 with Safari, and on Android 14 with Firefox

Before:
<img src="https://github.com/thoth-tech/doubtfire-web/assets/90136978/531046b1-2633-40b4-bed8-f0cd52f7e2ae" alt="before" width="400"/>

After:
<img src="https://github.com/thoth-tech/doubtfire-web/assets/90136978/a4a3258c-ae11-4e73-bf80-f163137a28a8" alt="after" width="400"/>

## Testing Checklist:

- [ ] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
