### PR TITLE
feat: implement numbas test data upload in task definition service

### DIFF
--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -158,7 +158,7 @@ export class TaskDefinition extends Entity {
 
   public getNumbasTestUrl(asAttachment: boolean = false) {
     const constants = AppInjector.get(DoubtfireConstants);
-    return `${constants.API_URL}/units/${this.unit.id}/task_definitions/${this.id}/numbas_test.json${
+    return `${constants.API_URL}/units/${this.unit.id}/task_definitions/${this.id}/numbas_data.json${
       asAttachment ? '?as_attachment=true' : ''
     }`;
   }
@@ -190,7 +190,7 @@ export class TaskDefinition extends Entity {
   public get numbasTestUploadUrl(): string {
     return `${AppInjector.get(DoubtfireConstants).API_URL}/units/${this.unit.id}/task_definitions/${
       this.id
-    }/numbas_test`;
+    }/numbas_data`;
   }
 
   public get taskAssessmentResourcesUploadUrl(): string {

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -139,4 +139,10 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
     formData.append('file', file);
     return AppInjector.get(HttpClient).post<boolean>(taskDefinition.taskAssessmentResourcesUploadUrl, formData);
   }
+
+  public uploadNumbasData(taskDefinition: TaskDefinition, file: File): Observable<boolean> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return AppInjector.get(HttpClient).post<boolean>(taskDefinition.numbasTestUploadUrl, formData);
+  }
 }

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
@@ -41,29 +41,13 @@ export class TaskDefinitionNumbasComponent {
     const validFiles = Array.from(files as ArrayLike<File>).filter((f) => f.type === 'application/zip');
     if (validFiles.length > 0) {
       const file = validFiles[0];
-      // Temporary until Numbas backend is fixed: save uploaded file to local Downloads folder
-      this.saveZipFile(file);
+      this.taskDefinitionService.uploadNumbasData(this.taskDefinition, file).subscribe({
+        next: () => this.alerts.add('success', 'Uploaded Numbas test data', 2000),
+        error: (message) => this.alerts.add('danger', message, 6000),
+      });
       this.taskDefinition.hasUploadedNumbasTest = true;
-      // this.taskDefinitionService.uploadNumbasTest(this.taskDefinition, file).subscribe({
-      //   next: () => this.alerts.add('success', 'Uploaded Numbas test', 2000),
-      //   error: (message) => this.alerts.add('danger', message, 6000),
-      // });
     } else {
-      this.alerts.add('danger', 'Please drop a ZIP to upload for this task', 6000);
+      this.alerts.add('danger', 'Please drop a zip file to upload Numbas test data for this task', 6000);
     }
-  }
-
-  private saveZipFile(zipData) {
-    const blob = new Blob([zipData], {type: 'application/zip'});
-
-    // Create an anchor element and set its href to the blob URL
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = 'numbas.zip';
-
-    // Append the link to the document, trigger the download, then remove the link
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
   }
 }


### PR DESCRIPTION
Some minor adjustments that goes along with the backend changes in https://github.com/thoth-tech/doubtfire-api/pull/15

- Implement numbas test data upload in task definition service
- Renamed api endpoint to reduce confusion between components

Tested the following actions with Chrome:
- [x] Upload
- [x] Download
- [x] Deletion

Note: Currently the frontend is unable to persist the status of the numbas test data (download/delete buttons are gone after refresh), which needs to be investigated separately.