### PR TITLE
fix: changed Numbas delay input and fixed attempt limit not showing on refresh

### DIFF
--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -33,7 +33,7 @@ export class TaskDefinition extends Entity {
   hasTaskResources: boolean;
   hasEnabledNumbasTest: boolean;
   hasNumbasData: boolean;
-  numbasTimeDelay: string = 'no delay';
+  hasNumbasTimeDelay: boolean;
   numbasAttemptLimit: number = 0;
   hasTaskAssessmentResources: boolean;
   isGraded: boolean;

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -105,7 +105,7 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'hasTaskAssessmentResources',
       'hasEnabledNumbasTest',
       'hasNumbasData',
-      'numbasTimeDelay',
+      'hasNumbasTimeDelay',
       'numbasAttemptLimit',
       'isGraded',
       'maxQualityPts',

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
@@ -24,16 +24,9 @@
 
   @if (taskDefinition.hasEnabledNumbasTest) {
     <div class="flex-grow flex flex-row gap-4 pt-4">
-      <mat-form-field appearance="outline" class="basis-1/2">
-        <mat-label>Time delay</mat-label>
-        <mat-select [(ngModel)]="taskDefinition.numbasTimeDelay">
-          <mat-option value="no delay">No delay</mat-option>
-          <mat-option value="30 min">30 min</mat-option>
-          <mat-option value="2 hours">2 hours</mat-option>
-          <mat-option value="1 day">1 day</mat-option>
-          <mat-option value="see tutor">See tutor</mat-option>
-        </mat-select>
-      </mat-form-field>
+      <mat-checkbox class="basis-1/2" matInput required [(ngModel)]="taskDefinition.hasNumbasTimeDelay">
+        Enable incremental time delays between test attempts
+      </mat-checkbox>
       <mat-form-field appearance="outline" class="basis-1/2">
         <mat-label>Attempt limit</mat-label>
         <input

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.html
@@ -35,14 +35,14 @@
         </mat-select>
       </mat-form-field>
       <mat-form-field appearance="outline" class="basis-1/2">
-        <mat-label>Attempt Limit</mat-label>
+        <mat-label>Attempt limit</mat-label>
         <input
           matInput
           min="0"
           max="100"
           type="number"
-          [(value)]="taskDefinition.numbasAttemptLimit"
-          [formControl]="scoreControl"
+          [(ngModel)]="taskDefinition.numbasAttemptLimit"
+          [formControl]="attemptLimitControl"
         />
       </mat-form-field>
     </div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-numbas/task-definition-numbas.component.ts
@@ -20,7 +20,7 @@ export class TaskDefinitionNumbasComponent {
     private taskDefinitionService: TaskDefinitionService
   ) {}
 
-  public scoreControl = new FormControl('', [Validators.max(100), Validators.min(0)]);
+  public attemptLimitControl = new FormControl('', [Validators.max(100), Validators.min(0)]);
 
   public get unit(): Unit {
     return this.taskDefinition?.unit;


### PR DESCRIPTION
# Description

Fixed the bug wherein the previously configured attempt limit won't show on refresh. Also changed the time delay input to a checkbox to enable incremental delays instead of specifying the delay.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

### Before

![Screenshot 2024-03-23 at 5 38 17 PM](https://github.com/thoth-tech/doubtfire-web/assets/117552851/c5212be7-2768-4fd0-aede-2215b87af9a2)

### After

<img width="1289" alt="image" src="https://github.com/thoth-tech/doubtfire-web/assets/117552851/6a37241d-4fcf-4f4c-92d3-18144cf7ea0c">

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
