### PR TITLE
feat: add task definition stages component

### DIFF
--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.html
@@ -1,0 +1,63 @@
+<table #stageTable mat-table [dataSource]="taskDefinition.stages" class="table-fixed">
+  <!-- Stage name Column -->
+  <ng-container matColumnDef="stage-name" sticky>
+    <th style="width: 30%" mat-header-cell *matHeaderCellDef>Stage</th>
+    <td style="width: 30%" mat-cell *matCellDef="let stage">
+      <mat-form-field appearance="outline">
+        <input matInput [(ngModel)]="stage.name" required />
+      </mat-form-field>
+    </td>
+  </ng-container>
+
+  <!-- Cases Column -->
+  <ng-container matColumnDef="cases" sticky>
+    <th style="width: 20%" mat-header-cell *matHeaderCellDef>Cases</th>
+    <td style="width: 20%" mat-cell *matCellDef="let stage">
+      <mat-select placeholder="-" [(ngModel)]="stage.cases">
+        <mat-option value="addressed">Addressed</mat-option>
+        <mat-option value="partial">Partially Addressed</mat-option>
+        <mat-option value="resubmit">Re-submit</mat-option>
+        <mat-option value="unaddressed">Unaddresed</mat-option>
+      </mat-select>
+    </td>
+  </ng-container>
+
+  <!-- Criteria Check Column -->
+  <ng-container matColumnDef="criteria" sticky>
+    <th style="width: 20%" mat-header-cell *matHeaderCellDef>Criteria</th>
+    <td style="width: 20%" mat-cell *matCellDef="let stage"></td>
+  </ng-container>
+
+  <!-- Actions -->
+  <ng-container matColumnDef="row-actions" sticky>
+    <th style="width: 10%" mat-header-cell *matHeaderCellDef></th>
+    <td style="width: 10%" mat-cell *matCellDef="let stage">
+      <button
+        mat-icon-button
+        aria-label="delete upload requirement"
+        color="warn"
+        (click)="removeStage(stage)"
+      >
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
+  <!-- Disclaimer column -->
+  <ng-container matColumnDef="actions">
+    <td mat-footer-cell *matFooterCellDef [colSpan]="columns.length">
+      <mat-toolbar>
+        <mat-toolbar-row>
+          <span class="flex flex-grow"></span>
+          <button mat-flat-button color="primary" (click)="addStage()">
+            <mat-icon>add</mat-icon> Add
+          </button>
+        </mat-toolbar-row>
+      </mat-toolbar>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="columns"></tr>
+  <tr mat-row *matRowDef="let row; columns: columns" class="table-row"></tr>
+  <tr mat-footer-row *matFooterRowDef="['actions']"></tr>
+</table>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.scss
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.scss
@@ -1,0 +1,8 @@
+.upload-card {
+  max-width: 400px;
+  margin-bottom: 8px;
+}
+
+.mat-toolbar {
+  background-color: white;
+}

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-stages/task-definition-stages.component.ts
@@ -1,0 +1,49 @@
+import {Component, Input, ViewChild} from '@angular/core';
+import {MatTable} from '@angular/material/table';
+import {TaskDefinition} from 'src/app/api/models/task-definition';
+import {Unit} from 'src/app/api/models/unit';
+import {Stage} from 'src/app/api/models/task-definition';
+@Component({
+  selector: 'f-task-definition-stages',
+  templateUrl: 'task-definition-stages.component.html',
+  styleUrls: ['task-definition-stages.component.scss'],
+})
+export class TaskDefinitionStagesComponent {
+  @Input() public taskDefinition: TaskDefinition;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  @ViewChild('stageTable', {static: true}) table: MatTable<any>;
+
+  public columns: string[] = ['title', 'order', 'criteria', 'cases', 'row-actions'];
+
+  public get unit(): Unit {
+    return this.taskDefinition?.unit;
+  }
+
+  public addStage() {
+    // check if the stages proprty exists in the taskDefinition object
+
+    if (!('stages' in this.taskDefinition)) {
+      // cannot add a stage if the stages property does not exist
+      console.error('Cannot add a stage if the stages property does not exist');
+      // exit the function
+      return;
+    }
+
+    const newLength = this.taskDefinition.stages.length + 1;
+    this.taskDefinition.stages.push({
+      id: newLength,
+      taskDefinitionId: this.taskDefinition.id,
+      title: `Stage ${newLength}`,
+      order: newLength - 1,
+      criteria: 'task',
+      cases: ['satisfactory'],
+    });
+    this.table.renderRows();
+  }
+
+  public removeStage(stage: Stage) {
+    this.taskDefinition.stages = this.taskDefinition.stages.filter(
+      (aStage) => aStage.id != stage.id,
+    );
+  }
+}


### PR DESCRIPTION
# Description

The commit made several changes:

1. Rebased to properly separate commits for each Trello card, ensuring a clean commit history.
1. Created a new front-end component named `TaskDefinitionStagesComponent` designed to interact with the backend API called `Stages`.

### Task Definition Stages Component

`TaskDefinitionStagesComponent` is an Angular component is used to manage stages in a task definition.

- `@Input() public taskDefinition: TaskDefinition;`: Declares an input property `taskDefinition` of type `TaskDefinition`. The `@Input()` decorator indicates that this property is a public API of the component and its value can be passed in by the component's parent.
- `@ViewChild('stageTable', {static: true}) table: MatTable<any>;`: Declares a view child property named `table`. The `@ViewChild()` decorator is used to access a child component, directive, or a DOM element from a parent component class. In this case, it's used to access the `MatTable` component with the template reference variable `#stageTable`.
- `public columns: string = 'title', 'order', 'criteria', 'cases', 'row-actions';`: Used to define the columns that should be displayed in the table.
- `public get unit(): Unit { return this.taskDefinition?.unit; }`: Getter method for `unit` property. Returns the `unit` property of the `taskDefinition` object.
- `public addStage() {…}`: Used to add a new stage to the `taskDefinition`. Checks if the `stages` property exists in the `taskDefinition` object. If it does, it creates a new stage object and pushes it to the `stages` array. It then calls `this.table.renderRows()` to update the table. Expected to be removed as all taskDefinitions should have a stages property.
- `public removeStage(stage: Stage) {…}`: Remove a stage from the `taskDefinition`. It does this by filtering out the stage from the `stages` array.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested by running local instance of OnTrack in both Safari and Chrome. Feature is WIP and not currently functional. 

## Testing Checklist:

- [ ] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have requested a review from @ublefo and @satikaj on the Pull Request