### PR TITLE
Summary task scatter

### DIFF
--- a/src/app/visualisations/summary-task-status-scatter.coffee
+++ b/src/app/visualisations/summary-task-status-scatter.coffee
@@ -1,29 +1,47 @@
 angular.module('doubtfire.visualisations.summary-task-status-scatter', [])
-.directive 'summaryTaskStatusScatter', ->
-  replace: true
-  restrict: 'E'
-  templateUrl: 'visualisations/visualisation.tpl.html'
-  scope:
-    data: '='
-    unit: '='
-  controller: ($scope, newTaskService, Visualisation) ->
-    yAxisTickFormatFunction = (value) ->
-      if $scope.unit.taskDefinitions[value]
-        $scope.unit.taskDefinitions[value].abbreviation
-      else
-        ''
 
-    xAxisTickFormatFunction = (value) ->
-      idx = Math.floor(value)
-      newTaskService.statusAcronym.get(newTaskService.statusKeys[idx])
+.directive('summaryTaskStatusScatter', function() {
+  return {
+    replace: true,
+    restrict: 'E',
+    templateUrl: 'visualisations/visualisation.tpl.html',
+    scope: {
+      data: '=',
+      unit: '='
+    },
+    controller: function($scope, newTaskService, Visualisation) {
+      // Function to format y-axis tick labels
+      var yAxisTickFormatFunction = function(value) {
+        if ($scope.unit.taskDefinitions[value]) {
+          return $scope.unit.taskDefinitions[value].abbreviation;
+        } else {
+          return '';
+        }
+      };
 
-    [$scope.options, $scope.config] = Visualisation 'scatterChart', 'Task Status Summary Scatter Chart', {
-      xAxis:
-        axisLabel: 'Statuses'
-        tickFormat: xAxisTickFormatFunction
-      yAxis:
-        axisLabel: 'Task'
-        tickFormat: yAxisTickFormatFunction
-      showDistX: yes
-      showDistY: yes
-    }, {}
+      ## Function to format x-axis tick labels
+      var xAxisTickFormatFunction = function(value) {
+        var idx = Math.floor(value);
+        return newTaskService.statusAcronym.get(newTaskService.statusKeys[idx]);
+      };
+
+      ## Set options and config for scatter chart
+      var [options, config] = Visualisation('scatterChart', 'Task Status Summary Scatter Chart', {
+        xAxis: {
+          axisLabel: 'Statuses',
+          tickFormat: xAxisTickFormatFunction
+        },
+        yAxis: {
+          axisLabel: 'Task',
+          tickFormat: yAxisTickFormatFunction
+        },
+        showDistX: true,
+        showDistY: true
+      }, {});
+
+      ##Assign options and config to scope
+      $scope.options = options;
+      $scope.config = config;
+    }
+  };
+});

--- a/src/app/visualisations/summary-task-status-scatter.coffee
+++ b/src/app/visualisations/summary-task-status-scatter.coffee
@@ -10,7 +10,7 @@ angular.module('doubtfire.visualisations.summary-task-status-scatter', [])
       unit: '='
     },
     controller: function($scope, newTaskService, Visualisation) {
-      // Function to format y-axis tick labels
+      ## Function to format y-axis tick labels
       var yAxisTickFormatFunction = function(value) {
         if ($scope.unit.taskDefinitions[value]) {
           return $scope.unit.taskDefinitions[value].abbreviation;

--- a/src/app/visualisations/summary-task-status-scatter.coffee
+++ b/src/app/visualisations/summary-task-status-scatter.coffee
@@ -1,47 +1,33 @@
 angular.module('doubtfire.visualisations.summary-task-status-scatter', [])
 
-.directive('summaryTaskStatusScatter', function() {
-  return {
-    replace: true,
-    restrict: 'E',
-    templateUrl: 'visualisations/visualisation.tpl.html',
-    scope: {
-      data: '=',
-      unit: '='
-    },
-    controller: function($scope, newTaskService, Visualisation) {
-      ## Function to format y-axis tick labels
-      var yAxisTickFormatFunction = function(value) {
-        if ($scope.unit.taskDefinitions[value]) {
-          return $scope.unit.taskDefinitions[value].abbreviation;
-        } else {
-          return '';
-        }
-      };
+.directive 'summaryTaskStatusScatter', ->
+  replace: true
+  restrict: 'E'
+  templateUrl: 'visualisations/visualisation.tpl.html'
+  scope:
+    data: '='
+    unit: '='
+  controller: ($scope, newTaskService, Visualisation) ->
+    # Function to format y-axis tick labels
+    yAxisTickFormatFunction = (value) ->
+      if $scope.unit.taskDefinitions[value]
+        $scope.unit.taskDefinitions[value].abbreviation
+      else
+        ''
 
-      ## Function to format x-axis tick labels
-      var xAxisTickFormatFunction = function(value) {
-        var idx = Math.floor(value);
-        return newTaskService.statusAcronym.get(newTaskService.statusKeys[idx]);
-      };
+    # Function to format x-axis tick labels
+    xAxisTickFormatFunction = (value) ->
+      idx = Math.floor(value)
+      newTaskService.statusAcronym.get(newTaskService.statusKeys[idx])
 
-      ## Set options and config for scatter chart
-      var [options, config] = Visualisation('scatterChart', 'Task Status Summary Scatter Chart', {
-        xAxis: {
-          axisLabel: 'Statuses',
-          tickFormat: xAxisTickFormatFunction
-        },
-        yAxis: {
-          axisLabel: 'Task',
-          tickFormat: yAxisTickFormatFunction
-        },
-        showDistX: true,
-        showDistY: true
-      }, {});
-
-      ##Assign options and config to scope
-      $scope.options = options;
-      $scope.config = config;
-    }
-  };
-});
+    # Set options and config for scatter chart
+    [$scope.options, $scope.config] = Visualisation 'scatterChart', 'Task Status Summary Scatter Chart', {
+      xAxis:
+        axisLabel: 'Statuses'
+        tickFormat: xAxisTickFormatFunction
+      yAxis:
+        axisLabel: 'Task'
+        tickFormat: yAxisTickFormatFunction
+      showDistX: yes
+      showDistY: yes
+    }, {}


### PR DESCRIPTION
# Description

Front end migration of summary-task-status-scatter.coffee. This file has now been updated to allow future changes to be made easier and the code easier to understand and modify.

## Type of change

- [X ] This change requires a documentation update

# How Has This Been Tested?

This has been tested by verifying on the student end if the task summary was the same as before, looks and how it works wise. in which it is the case as seen below

Pre-changes
<img width="1470" alt="Screenshot 2024-04-19 at 12 29 49 AM" src="https://github.com/thoth-tech/doubtfire-web/assets/80439444/e7773e62-8168-45b0-ab0a-9b7c9906b41e">

Post-changes
<img width="1470" alt="Screenshot 2024-04-19 at 12 30 03 AM" src="https://github.com/thoth-tech/doubtfire-web/assets/80439444/85bb5c1c-a97a-452b-956f-263a113b3b6d">

## Testing Checklist:

- [X ] Tested in latest Chrome
- [ X] Tested in latest Safari

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [X ] I have requested a review from @macite and @jakerenzella on the Pull Request
