### PR TITLE
refactor: refactor extension to days

### DIFF
--- a/src/app/api/models/task-comment/extension-comment.ts
+++ b/src/app/api/models/task-comment/extension-comment.ts
@@ -12,7 +12,7 @@ export class ExtensionComment extends TaskComment {
   granted: boolean;
   extensionResponse: string;
   dateAssessed: Date;
-  weeksRequested: number;
+  daysRequested: number;
 
   taskStatus: string;
   taskDueDate: Date;

--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -689,7 +689,7 @@ export class Task extends Entity {
       this.unit.allowStudentExtensionRequests &&
       this.inStateThatAllowsExtension() &&
       (!this.isPastDeadline() || this.wasSubmittedOnTime()) &&
-      this.maxWeeksCanExtend() > 0
+      this.maxDaysCanExtend() > 0
     );
   }
 
@@ -697,20 +697,20 @@ export class Task extends Entity {
     return this.submissionDate && this.submissionDate.getTime() <= this.definition.finalDeadlineDate().getTime();
   }
 
-  public maxWeeksCanExtend(): number {
-    return Math.ceil(this.daysBetween(this.localDueDate(), this.definition.localDeadlineDate()) / 7);
+  public maxDaysCanExtend(): number {
+    return this.daysBetween(this.localDueDate(), this.definition.localDeadlineDate());
   }
 
   /**
-   * Returns the minimum number of weeks the task must be extended to be
+   * Returns the minimum number of days the task must be extended to be
    * able to available for tutors to provide feedback.
    */
-  public minWeeksCanExtend(): number {
-    const minWeeks = Math.ceil(this.daysBetween(this.localDueDate(), new Date()) / 7);
-    if (minWeeks < 0) {
+  public minDaysCanExtend(): number {
+    const minDays = Math.ceil(this.daysBetween(this.localDueDate(), new Date()));
+    if (minDays < 0) {
       return 0;
     } else {
-      return minWeeks;
+      return minDays;
     }
   }
 

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -60,7 +60,7 @@ export class Unit extends Entity {
   draftTaskDefinition: TaskDefinition;
 
   allowStudentExtensionRequests: boolean;
-  extensionWeeksOnResubmitRequest: number;
+  extensionDaysOnResubmitRequest: number;
   allowStudentChangeTutorial: boolean;
 
   public readonly learningOutcomesCache: EntityCache<LearningOutcome> = new EntityCache<LearningOutcome>();

--- a/src/app/api/services/task-comment.service.ts
+++ b/src/app/api/services/task-comment.service.ts
@@ -76,7 +76,7 @@ export class TaskCommentService extends CachedEntityService<TaskComment> {
       'extensionResponse',
       'granted',
       'dateAssessed',
-      'weeksRequested',
+      'daysRequested',
       'taskStatus',
       ['taskDueDate', 'due_date'],
       ['taskExtensions', 'extensions'],
@@ -184,12 +184,12 @@ export class TaskCommentService extends CachedEntityService<TaskComment> {
     );
   }
 
-  public requestExtension(reason: string, weeksRequested: number, task: any): Observable<TaskComment> {
+  public requestExtension(reason: string, daysRequested: number, task: any): Observable<TaskComment> {
     const opts: RequestOptions<TaskComment> = {
       endpointFormat: this.requestExtensionEndpointFormat,
       body: {
         comment: reason,
-        weeks_requested: weeksRequested,
+        days_requested: daysRequested,
       },
       cache: task.commentCache
     };

--- a/src/app/api/services/unit.service.ts
+++ b/src/app/api/services/unit.service.ts
@@ -128,7 +128,7 @@ export class UnitService extends CachedEntityService<Unit> {
       'enableSyncEnrolments',
       'enableSyncTimetable',
       'allowStudentExtensionRequests',
-      'extensionWeeksOnResubmitRequest',
+      'extensionDaysOnResubmitRequest',
       'allowStudentChangeTutorial',
       {
         keys: 'ilos',
@@ -234,7 +234,7 @@ export class UnitService extends CachedEntityService<Unit> {
 
       'draftTaskDefinition',
       'allowStudentExtensionRequests',
-      'extensionWeeksOnResubmitRequest',
+      'extensionDaysOnResubmitRequest',
       'allowStudentChangeTutorial'
     );
   }

--- a/src/app/common/modals/extension-modal/extension-modal.component.html
+++ b/src/app/common/modals/extension-modal/extension-modal.component.html
@@ -12,13 +12,12 @@
 
   <p>Requesting extension to: {{ newDueDate }}</p>
   <mat-slider
-    id="requestWeekSlider"
-    thumbLabel
-    [min]="minWeeksCanExtend"
-    [max]="maxWeeksCanExtend"
+    id="requestDaySlider"
+    [min]="minDaysCanExtend"
+    [max]="maxDaysCanExtend"
     step="1"
-    [(ngModel)]="weeksRequested"
-    ><input matSliderThumb /><input matSliderThumb />
+    [(ngModel)]="daysRequested"
+    ><input matSliderThumb />
   </mat-slider>
 </div>
 
@@ -30,9 +29,9 @@
     mat-stroked-button
     color="primary"
     mat-button
-    [disabled]="weeksRequested === 0 || reason.length < 15"
+    [disabled]="daysRequested === 0 || reason.length < 15"
     (click)="submitApplication()"
   >
-    Request {{ weeksRequested }} {{ weeksRequested === 1 ? 'week' : 'weeks' }}
+    Request {{ daysRequested }} {{ daysRequested === 1 ? 'day' : 'days' }}
   </button>
 </div>

--- a/src/app/common/modals/extension-modal/extension-modal.component.scss
+++ b/src/app/common/modals/extension-modal/extension-modal.component.scss
@@ -1,5 +1,5 @@
-#requestWeekSlider {
-  width: 100%;
+#requestDaySlider {
+  width: 95%;
 }
 
 

--- a/src/app/common/modals/extension-modal/extension-modal.component.ts
+++ b/src/app/common/modals/extension-modal/extension-modal.component.ts
@@ -12,7 +12,7 @@ import { formatDate } from '@angular/common';
   styleUrls: ['./extension-modal.component.scss'],
 })
 export class ExtensionModalComponent implements OnInit {
-  weeksRequested: number;
+  daysRequested: number;
   reason: string = '';
   constructor(
     public dialogRef: MatDialogRef<ExtensionModalComponent>,
@@ -21,14 +21,14 @@ export class ExtensionModalComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.weeksRequested = this.minWeeksCanExtend + 1;
-    if (this.weeksRequested > this.maxWeeksCanExtend) {
-      this.weeksRequested = this.maxWeeksCanExtend;
+    this.daysRequested = this.minDaysCanExtend + 1;
+    if (this.daysRequested > this.maxDaysCanExtend) {
+      this.daysRequested = this.maxDaysCanExtend;
     }
   }
 
   get newDueDate() {
-    const calculatedDueDate = new Date(this.data.task.localDueDate().getTime() + this.weeksRequested * 1000 * 60 * 60 * 24 * 7 );
+    const calculatedDueDate = new Date(this.data.task.localDueDate().getTime() + this.daysRequested * 1000 * 60 * 60 * 24 );
     const taskDeadlineDate: Date = this.data.task.definition.localDeadlineDate();
 
     const locale: string = AppInjector.get(LOCALE_ID);
@@ -40,12 +40,12 @@ export class ExtensionModalComponent implements OnInit {
     }
   }
 
-  get maxWeeksCanExtend() {
-    return this.data.task.maxWeeksCanExtend();
+  get maxDaysCanExtend() {
+    return this.data.task.maxDaysCanExtend();
   }
 
-  get minWeeksCanExtend() {
-    return this.data.task.minWeeksCanExtend();
+  get minDaysCanExtend() {
+    return this.data.task.minDaysCanExtend();
   }
 
   private scrollCommentsDown(): void {
@@ -59,7 +59,7 @@ export class ExtensionModalComponent implements OnInit {
   submitApplication() {
     const tcs: TaskCommentService = AppInjector.get(TaskCommentService);
 
-    tcs.requestExtension(this.reason, this.weeksRequested, this.data.task).subscribe({
+    tcs.requestExtension(this.reason, this.daysRequested, this.data.task).subscribe({
       next: ((tc: TaskComment) => {
         this.alerts.add('success', 'Extension requested.', 2000);
         this.scrollCommentsDown();

--- a/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.ts
+++ b/src/app/tasks/task-comments-viewer/extension-comment/extension-comment.component.ts
@@ -26,8 +26,8 @@ export class ExtensionCommentComponent implements OnInit {
       return this.comment.extensionResponse;
     }
     const subject = this.isStudent ? 'You have ' : studentName + ' has ';
-    const message = `requested an extension for ${this.comment.weeksRequested} ${
-      this.comment.weeksRequested === 1 ? 'week' : 'weeks'
+    const message = `requested an extension for ${this.comment.daysRequested} ${
+      this.comment.daysRequested === 1 ? 'day' : 'days'
     }.`;
     return subject + message;
   }

--- a/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.tpl.html
@@ -201,16 +201,16 @@
               class="form-control"
               id="code"
               type="number"
-              placeholder="1"
-              ng-model="unit.extensionWeeksOnResubmitRequest"
+              placeholder="7"
+              ng-model="unit.extensionDaysOnResubmitRequest"
             />
             <span class="help-block">
-              When tutors request resubmission of a task, this setting determines how many weeks the task will be
+              When tutors request resubmission of a task, this setting determines how many days the task will be
               extended to allow students to fix and resubmit their work.
             </span>
           </div>
         </div>
-        <!--/extensionWeeksOnResubmitRequest-->
+        <!--/extensionDaysOnResubmitRequest-->
 
         <div class="form-group">
           <label class="col-sm-2 control-label" for="enddate">Auto apply extensions</label>


### PR DESCRIPTION
Refactor extension system to use days instead of weeks to provide better flexibility.

Note I am unable to get this to work correctly as the slider for adjusting extension length is broken, so I can only request 1 day with the frontend no matter what. Any help to troubleshoot this would be highly appreciated.

Related backend change: https://github.com/thoth-tech/doubtfire-api/pull/23