### PR TITLE
feat: persistent pdf viewer zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [8.0.28](https://github.com/macite/doubtfire-deploy/compare/v8.0.23...v8.0.28) (2024-09-05)
+
+
+### Features
+
+* add support for the view language ([b4b3654](https://github.com/macite/doubtfire-deploy/commit/b4b36541943232f7df3ee4888bf4ca46c4c04018))
+
 ### [8.0.23](https://github.com/macite/doubtfire-deploy/compare/v8.0.22...v8.0.23) (2024-08-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubtfire",
-  "version": "8.0.23",
+  "version": "8.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubtfire",
-      "version": "8.0.23",
+      "version": "8.0.28",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubtfire",
-  "version": "8.0.23",
+  "version": "8.0.28",
   "homepage": "http://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",

--- a/src/app/common/file-uploader/file-uploader.coffee
+++ b/src/app/common/file-uploader/file-uploader.coffee
@@ -68,7 +68,7 @@ angular.module('doubtfire.common.file-uploader', ["ngFileUpload"])
         extensions: ['pas', 'cpp', 'c', 'cs', 'csv', 'h', 'hpp', 'java', 'py', 'js', 'html', 'coffee', 'rb', 'css',
                     'scss', 'yaml', 'yml', 'xml', 'json', 'ts', 'r', 'rmd', 'rnw', 'rhtml', 'rpres', 'tex',
                     'vb', 'sql', 'txt', 'md', 'jack', 'hack', 'asm', 'hdl', 'tst', 'out', 'cmp', 'vm', 'sh', 'bat',
-                    'dat', 'ipynb', 'pml']
+                    'dat', 'ipynb', 'pml', 'vue']
         icon:       'fa-file-code-o'
         name:       'code'
       image:

--- a/src/app/common/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/common/pdf-viewer/pdf-viewer.component.ts
@@ -19,6 +19,9 @@ import {AlertService} from '../services/alert.service';
   styleUrls: ['./pdf-viewer.component.scss'],
 })
 export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit {
+  private readonly ZOOM_MIN = 0.5;
+  private readonly ZOOM_MAX = 2.5;
+
   private _pdfUrl: string;
   public pdfBlobUrl: string;
   public useNativePdfViewer = false;
@@ -43,6 +46,9 @@ export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit 
 
   ngAfterViewInit(): void {
     this.useNativePdfViewer = localStorage.getItem('useNativePdfViewer') === 'true';
+    const storedZoomValue = parseFloat(localStorage.getItem('pdfViewerZoom')) || 1;
+    // Clamp zoom value between ZOOM_MIN and ZOOM_MAX
+    this.zoomValue = Math.min(Math.max(storedZoomValue, this.ZOOM_MIN), this.ZOOM_MAX);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -76,13 +82,15 @@ export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit 
   }
 
   public zoomIn() {
-    if (this.zoomValue < 2.5) {
+    if (this.zoomValue < this.ZOOM_MAX) {
       this.zoomValue += 0.1;
+      localStorage.setItem('pdfViewerZoom', this.zoomValue.toString());
     }
   }
   public zoomOut() {
-    if (this.zoomValue > 0.5) {
+    if (this.zoomValue > this.ZOOM_MIN) {
       this.zoomValue -= 0.1;
+      localStorage.setItem('pdfViewerZoom', this.zoomValue.toString());
     }
   }
 


### PR DESCRIPTION
# Description

This change ensures that zoom levels in the pdf-viewer component persist across different PDFs and user submissions, instead of resetting to the default zoom every time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Login as `atutor` or `aconvenor` and select the inbox/explorer tab to view a list of student submissions.
Select one of the submissions and modify the zoom level.
Select a different submission and/or refresh the page to verify that the zoom level remains the same.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
