### PR TITLE
Bugfix/markdown bugfix new

### DIFF
--- a/src/app/common/pipes/marked.pipe.ts
+++ b/src/app/common/pipes/marked.pipe.ts
@@ -1,12 +1,12 @@
-import {Pipe, PipeTransform} from '@angular/core';
+import { Pipe, PipeTransform } from '@angular/core';
 import * as marked from 'marked';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Pipe({
   name: 'marked',
 })
 export class MarkedPipe implements PipeTransform {
-  // Set the options for the markdown renderer
-  constructor() {
+  constructor(private sanitizer: DomSanitizer) {
     marked.setOptions({
       renderer: new marked.Renderer(),
       pedantic: false,
@@ -15,10 +15,17 @@ export class MarkedPipe implements PipeTransform {
     });
   }
 
-  transform(value: string, ...args: any[]): string {
+  transform(value: string, ...args: any[]): SafeHtml {
     if (value && value.length > 0) {
-      return <string>marked.parse(value.replaceAll(/\r\n|\r|\n/g, '<br />'), {async: false});
+      const parsedValue = value;
+      const html = <string>marked.parse(parsedValue, {async: false});
+      console.log(html);
+
+      // Sanitizing the HTML for safe rendering
+      return this.sanitizer.bypassSecurityTrustHtml(html);
     }
-    return value;
+
+    // Return empty or unmodified value as safe HTML
+    return this.sanitizer.bypassSecurityTrustHtml(value || '');
   }
 }

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.html
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.html
@@ -34,7 +34,7 @@
             class="comment"
             [ngClass]="{
               'comment-by-other-user': !comment.authorIsMe,
-              'new-comment': comment.isNew
+              'new-comment': comment.isNew,
             }"
             [fxLayout]="comment.authorIsMe ? 'row-reverse' : 'row'"
             fxLayoutAlign="start end"

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
@@ -8,6 +8,23 @@
   margin: 0 0 0 0px !important;
 }
 
+::ng-deep .text-bubble .comment-text .markdown-to-html ul {
+  list-style-type: disc !important;
+  margin: 0 0 1em 0.75em !important;
+  padding: 0 0 0 0.75em !important;
+}
+
+::ng-deep .text-bubble .comment-text .markdown-to-html ol {
+  list-style-type: decimal !important;
+  margin: 0 0 1em 0.75em !important;
+  padding: 0 0 0 0.75em !important;
+}
+
+::ng-deep .text-bubble .comment-text .markdown-to-html li {
+  margin: 0 0 0.5em 0 !important;
+}
+
+
 $comment-bubble-color: #3939ff;
 $comment-bubble-color-darker: darken($comment-bubble-color, 10%);
 $comment-bubble-color-other-user: rgb(241, 240, 240);
@@ -498,6 +515,8 @@ $comment-inner-border-radius: 4px;
       width: 100%;
     }
   }
+
+
 
   #contextOverlay {
     position: absolute;

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.ts
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @angular-eslint/component-selector */
 import { Component, OnInit, Input, Inject, OnChanges, SimpleChanges, ViewChild, ElementRef } from '@angular/core';
 import { commentsModal } from 'src/app/ajs-upgraded-providers';
 import { Task, Project, TaskComment, TaskCommentService } from 'src/app/api/models/doubtfire-model';


### PR DESCRIPTION
# Description
Fixes the Markdown chat bug, specifically those connected to lists. 

#Fixes (issue)
Modified the Marked Pipe to _not_ automatically replace all linebreaks with the <br> tag. The Marked Pipe by itself should process it. Implemented a DomSanitizer to pass SafeHTML format files to be processed by Angular, and then made the CSS explicit to render the Markdown results as lists.

## Type of change
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update
 
# How Has This Been Tested?
Logged on as a tutor and typed in the chat. Large texts should display properly now, and lists should be displayed and indented properly. 

## Testing Checklist:
* [ ]  Tested in latest Chrome
* [ ]  Tested in latest Safari
* [ ]  Tested in latest Firefox

# Checklist:
* [ ]  My code follows the style guidelines of this project
* [ ]  I have performed a self-review of my own code
* [ ]  I have commented my code in hard-to-understand areas
* [ ]  I have made corresponding changes to the documentation
* [ ]  My changes generate no new warnings

