### PR TITLE
fix: correct a typo in /edit_profile

### DIFF
--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -122,7 +122,7 @@
       @if(tiiEnabled){
       <section fxLayout="row" fxFlexFill fxLayoutAlign="start center">
         <mat-checkbox color="primary" [(ngModel)]="user.acceptedTiiEula" [disableRipple]="true" (click)="$event.preventDefault()" name="acceptedTiiEula" disabled
-          >Acceptted TurnItIn EULA
+          >Accepted TurnItIn EULA
         </mat-checkbox>
       </section>
       }


### PR DESCRIPTION
# Description

When tiiEnabled=true the checkbox was displaying a typo 

Fixes # New Task "Fix typo in /edit_profile" 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

GIVEN TII_ENABLED: true 
as a student
navigate to /edit_profile
Checkbox should read "Accepted TurnItIn EULA"

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
