### PR TITLE
Update/Course map feature

### DIFF
--- a/src/app/api/models/course-map-unit.ts
+++ b/src/app/api/models/course-map-unit.ts
@@ -6,3 +6,4 @@ export interface CourseMapUnit {
   teachingPeriodSlot: number;
   unitSlot: number;
 }
+

--- a/src/app/api/models/course-map-unit.ts
+++ b/src/app/api/models/course-map-unit.ts
@@ -3,6 +3,6 @@ export interface CourseMapUnit {
   courseMapId: number;
   unitId: number;
   yearSlot: number;
-  teachingPeriodSlow: number;
+  teachingPeriodSlot: number;
   unitSlot: number;
 }

--- a/src/app/api/models/course-map-unit.ts
+++ b/src/app/api/models/course-map-unit.ts
@@ -1,0 +1,8 @@
+export interface CourseMapUnit {
+  id?: string;
+  courseMapId: number;
+  unitId: number;
+  yearSlot: number;
+  teachingPeriodSlow: number;
+  unitSlot: number;
+}

--- a/src/app/api/models/course-map.ts
+++ b/src/app/api/models/course-map.ts
@@ -1,0 +1,5 @@
+export interface CourseMap {
+  id?: string;
+  userId: number;
+  courseId: number;
+}

--- a/src/app/api/models/course-map.ts
+++ b/src/app/api/models/course-map.ts
@@ -3,3 +3,4 @@ export interface CourseMap {
   userId: number;
   courseId: number;
 }
+

--- a/src/app/api/models/course.ts
+++ b/src/app/api/models/course.ts
@@ -1,0 +1,8 @@
+export interface Course {
+  id?: string;
+  name: string;
+  code: string;
+  year: number;
+  version: string;
+  url: string;
+}

--- a/src/app/api/models/course.ts
+++ b/src/app/api/models/course.ts
@@ -6,3 +6,4 @@ export interface Course {
   version: string;
   url: string;
 }
+

--- a/src/app/api/models/doubtfire-model.ts
+++ b/src/app/api/models/doubtfire-model.ts
@@ -34,6 +34,7 @@ export * from './task-similarity';
 export * from './tii-action';
 export * from './course';
 export * from './course-map';
+export * from './course-map-unit';
 export * from './unit-definition';
 export * from './requirement-set';
 

--- a/src/app/api/models/doubtfire-model.ts
+++ b/src/app/api/models/doubtfire-model.ts
@@ -45,6 +45,7 @@ export * from './user/user';
 export * from './webcal/webcal';
 
 
+
 export * from '../services/authentication.service';
 export * from '../services/unit.service';
 export * from '../services/project.service';

--- a/src/app/api/models/doubtfire-model.ts
+++ b/src/app/api/models/doubtfire-model.ts
@@ -33,6 +33,7 @@ export * from '../services/task-outcome-alignment.service';
 export * from './task-similarity';
 export * from './tii-action';
 export * from './course';
+export * from './course-map';
 
 // Users -- are students or staff
 export * from './user/user';

--- a/src/app/api/models/doubtfire-model.ts
+++ b/src/app/api/models/doubtfire-model.ts
@@ -34,6 +34,8 @@ export * from './task-similarity';
 export * from './tii-action';
 export * from './course';
 export * from './course-map';
+export * from './unit-definition';
+export * from './requirement-set';
 
 // Users -- are students or staff
 export * from './user/user';

--- a/src/app/api/models/doubtfire-model.ts
+++ b/src/app/api/models/doubtfire-model.ts
@@ -32,6 +32,7 @@ export * from './task-comment/discussion-comment';
 export * from '../services/task-outcome-alignment.service';
 export * from './task-similarity';
 export * from './tii-action';
+export * from './course';
 
 // Users -- are students or staff
 export * from './user/user';

--- a/src/app/api/models/requirement-set.ts
+++ b/src/app/api/models/requirement-set.ts
@@ -1,0 +1,7 @@
+export interface RequirementSet {
+  id?: string;
+  requirementSetGroupId: number;
+  description: string;
+  unitId: number;
+  requirementId: number;
+}

--- a/src/app/api/models/requirement-set.ts
+++ b/src/app/api/models/requirement-set.ts
@@ -5,3 +5,4 @@ export interface RequirementSet {
   unitId: number;
   requirementId: number;
 }
+

--- a/src/app/api/models/unit-definition.ts
+++ b/src/app/api/models/unit-definition.ts
@@ -4,3 +4,4 @@ export interface UnitDefinition {
   description: string;
   code: string;
 }
+

--- a/src/app/api/models/unit-definition.ts
+++ b/src/app/api/models/unit-definition.ts
@@ -1,0 +1,7 @@
+export interface UnitDefinition {
+  id?: string;
+  unitDefinitionId: number;
+  name: string;
+  description: string;
+  code: string;
+}

--- a/src/app/api/models/unit-definition.ts
+++ b/src/app/api/models/unit-definition.ts
@@ -1,6 +1,5 @@
 export interface UnitDefinition {
-  id?: string;
-  unitDefinitionId: number;
+  id?: number;
   name: string;
   description: string;
   code: string;

--- a/src/app/api/services/course-map-unit.service.ts
+++ b/src/app/api/services/course-map-unit.service.ts
@@ -1,0 +1,64 @@
+import {Unit} from 'src/app/api/models/doubtfire-model';
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import API_URL from 'src/app/config/constants/apiURL';
+
+@Injectable()
+export class CourseMapUnitService {
+
+  constructor(private http: HttpClient) {}
+
+  private baseUrl: string = `${API_URL}/coursemapunit`;
+
+  // Get course-map-units
+  getCourseMapUnits(): Observable<Unit> {
+    const url = `${this.baseUrl}`;
+    return this.http.get<Unit>(url);
+  }
+
+  addCourseMapUnit(
+    courseMapId: number,
+    unitId: number,
+    yearSlot: number,
+    teachingPeriodSlow: number,
+    unitSlot: number,
+  ): Observable<Unit> {
+    const url = `${this.baseUrl}`;
+    const params = new HttpParams();
+    params.set('courseMapId', courseMapId.toString());
+    params.set('unitId', unitId.toString());
+    params.set('yearSlot', yearSlot.toString());
+    params.set('teachingPeriodSlot', teachingPeriodSlow.toString());
+    params.set('unitSlot', unitSlot.toString());
+    return this.http.post<Unit>(url, {params});
+  }
+
+  updateCourseMapUnit(
+    courseMapUnitId: number,
+    courseMapId: number,
+    unitId: number,
+    yearSlot: number,
+    teachingPeriodSlow: number,
+    unitSlot: number,
+  ): Observable<Unit> {
+    const url = `${this.baseUrl}/courseMapUnitId/${courseMapUnitId}`;
+    const params = new HttpParams();
+    params.set('courseMapId', courseMapId.toString());
+    params.set('unitId', unitId.toString());
+    params.set('yearSlot', yearSlot.toString());
+    params.set('teachingPeriodSlot', teachingPeriodSlow.toString());
+    params.set('unitSlot', unitSlot.toString());
+    return this.http.put<Unit>(url, {params});
+  }
+
+  deleteAllCourseMapUnitsByCourseMapId(courseMapId: number): Observable<Unit> {
+    const url = `${this.baseUrl}/courseMapId/${courseMapId}`;
+    return this.http.delete<Unit>(url);
+  }
+
+  deleteCourseMapUnitById(courseMapUnitId: number): Observable<Unit> {
+    const url = `${this.baseUrl}/courseMapUnitId/${courseMapUnitId}`;
+    return this.http.delete<Unit>(url);
+  }
+}

--- a/src/app/api/services/course-map-unit.service.ts
+++ b/src/app/api/services/course-map-unit.service.ts
@@ -1,10 +1,13 @@
-import {Unit} from 'src/app/api/models/doubtfire-model';
+import {Unit, CourseMapUnit} from 'src/app/api/models/doubtfire-model';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import API_URL from 'src/app/config/constants/apiURL';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+}
+)
 export class CourseMapUnitService {
 
   constructor(private http: HttpClient) {}
@@ -12,16 +15,16 @@ export class CourseMapUnitService {
   private baseUrl: string = `${API_URL}/coursemapunit`;
 
   // Get course-map-units
-  getCourseMapUnits(): Observable<Unit> {
-    const url = `${this.baseUrl}`;
-    return this.http.get<Unit>(url);
+  getCourseMapUnitsById(id): Observable<CourseMapUnit[]> {
+    const url = `${this.baseUrl}/courseMapId/${id}`;
+    return this.http.get<CourseMapUnit[]>(url);
   }
 
   addCourseMapUnit(
     courseMapId: number,
     unitId: number,
     yearSlot: number,
-    teachingPeriodSlow: number,
+    teachingPeriodSlot: number,
     unitSlot: number,
   ): Observable<Unit> {
     const url = `${this.baseUrl}`;
@@ -29,7 +32,7 @@ export class CourseMapUnitService {
     params.set('courseMapId', courseMapId.toString());
     params.set('unitId', unitId.toString());
     params.set('yearSlot', yearSlot.toString());
-    params.set('teachingPeriodSlot', teachingPeriodSlow.toString());
+    params.set('teachingPeriodSlot', teachingPeriodSlot.toString());
     params.set('unitSlot', unitSlot.toString());
     return this.http.post<Unit>(url, {params});
   }

--- a/src/app/api/services/course-map.service.ts
+++ b/src/app/api/services/course-map.service.ts
@@ -10,7 +10,6 @@ import API_URL from 'src/app/config/constants/apiURL';
 export class CourseMapService {
 
   private baseUrl: string = `${API_URL}/coursemap`;
-
   constructor(private http: HttpClient) {}
 
   // Get course map by user ID

--- a/src/app/api/services/course-map.service.ts
+++ b/src/app/api/services/course-map.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CourseMap } from '../models/doubtfire-model';
+import API_URL from 'src/app/config/constants/apiURL';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CourseMapService {
+
+  private baseUrl: string = `${API_URL}/coursemap`;
+
+  constructor(private http: HttpClient) {}
+
+  // Get course map by user ID
+  getCourseMapByUserId(userId: number): Observable<CourseMap> {
+    const url = `${this.baseUrl}/userId/${userId}`;
+    return this.http.get<CourseMap>(url);
+  }
+
+  // Get course map by course ID
+  getCourseMapByCourseId(courseId: number): Observable<CourseMap[]> {
+    const url = `${this.baseUrl}/courseId/${courseId}`;
+    return this.http.get<CourseMap[]>(url);
+  }
+
+  // Add a new course map
+  addCourseMap(userId: number, courseId: number): Observable<CourseMap> {
+    const url = `${this.baseUrl}`;
+    return this.http.post<CourseMap>(url, { userId, courseId });
+  }
+
+  // Update an existing course map by its ID
+  updateCourseMap(courseMapId: number, userId: number, courseId: number): Observable<CourseMap> {
+    const url = `${this.baseUrl}/courseMapId/${courseMapId}`;
+    return this.http.put<CourseMap>(url, { userId, courseId });
+  }
+
+  // Delete a course map by its ID
+  deleteCourseMapById(courseMapId: number): Observable<void> {
+    const url = `${this.baseUrl}/courseMapId/${courseMapId}`;
+    return this.http.delete<void>(url);
+  }
+
+  // Delete all course maps by user ID
+  deleteCourseMapsByUserId(userId: number): Observable<void> {
+    const url = `${this.baseUrl}/userId/${userId}`;
+    return this.http.delete<void>(url);
+  }
+}

--- a/src/app/api/services/course.service.ts
+++ b/src/app/api/services/course.service.ts
@@ -22,7 +22,9 @@ export class CourseService {
   }
 
   createCourse(course: Course): Observable<Course> {
-    return this.http.post<Course>(API_URL, course);
+    const url = `${API_URL}/course/`;
+
+    return this.http.post<Course>(url, course);
   }
 
   updateCourse(id: string, course: Course): Observable<Course> {

--- a/src/app/api/services/course.service.ts
+++ b/src/app/api/services/course.service.ts
@@ -13,7 +13,7 @@ export class CourseService {
 
   getCourses(): Observable<Course[]> {
     const url = `${API_URL}/course/`;
-    console.log("fetched");
+    console.log("fetched courses");
     return this.http.get<Course[]>(url);
   }
 

--- a/src/app/api/services/course.service.ts
+++ b/src/app/api/services/course.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Course } from '../models/course';
+import API_URL from 'src/app/config/constants/apiURL';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CourseService {
+
+  constructor(private http: HttpClient) {}
+
+  getCourses(): Observable<Course[]> {
+    const url = `${API_URL}/course/`;
+    console.log("fetched");
+    return this.http.get<Course[]>(url);
+  }
+
+  getCourseById(id: string): Observable<Course> {
+    return this.http.get<Course>(`${API_URL}/course/${id}`);
+  }
+
+  createCourse(course: Course): Observable<Course> {
+    return this.http.post<Course>(API_URL, course);
+  }
+
+  updateCourse(id: string, course: Course): Observable<Course> {
+    return this.http.put<Course>(`${API_URL}/course/${id}`, course);
+  }
+
+  deleteCourse(id: string): Observable<void> {
+    return this.http.delete<void>(`${API_URL}/course/${id}`);
+  }
+}

--- a/src/app/api/services/course.service.ts
+++ b/src/app/api/services/course.service.ts
@@ -8,7 +8,6 @@ import API_URL from 'src/app/config/constants/apiURL';
   providedIn: 'root'
 })
 export class CourseService {
-
   constructor(private http: HttpClient) {}
 
   getCourses(): Observable<Course[]> {

--- a/src/app/api/services/requirement-set.service.ts
+++ b/src/app/api/services/requirement-set.service.ts
@@ -1,0 +1,59 @@
+import {Observable} from 'rxjs';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import API_URL from 'src/app/config/constants/apiURL';
+
+@Injectable()
+export class RequirementSet {
+
+  constructor(private http: HttpClient) {}
+
+  private baseUrl: string = `${API_URL}/requirementset`;
+
+  // Get requirement-sets
+  getRequirementSets(): Observable<RequirementSet> {
+    const url = `${this.baseUrl}`;
+    return this.http.get<RequirementSet>(url);
+  }
+
+  getRequirementSetById(): Observable<RequirementSet> {
+    const url = `${this.baseUrl}/:id:`;
+    return this.http.get<RequirementSet>(url);
+  }
+
+  addNewRequirementSet(
+    requirementSetGroupId: number,
+    name: string,
+    description: string,
+    unitId: string,
+    requirementId: number): Observable<RequirementSet> {
+    const params = new HttpParams();
+
+    params.set('requirementSetId', requirementSetGroupId.toString());
+    params.set('name', name);
+    params.set('description', description);
+    params.set('unitId', unitId);
+    params.set('requirementId', requirementId.toString());
+    const url = `${this.baseUrl}`;
+    return this.http.post<RequirementSet>(url, {params});
+  }
+
+  updateRequirementSet(
+    requirementSetGroupId: number,
+    name: string,
+    description: string,
+    code: string,): Observable<RequirementSet> {
+    const params = new HttpParams();
+
+    params.set('requirementSetId', requirementSetGroupId.toString());
+    params.set('description', description);
+    const url = `${this.baseUrl}`;
+    return this.http.put<RequirementSet>(url, {params});
+  }
+
+  deleteRequirementSet(requirementSetGroupId: number): Observable<RequirementSet> {
+    const url = `${this.baseUrl}/requirementSetId/${requirementSetGroupId}`;
+    return this.http.delete<RequirementSet>(url);
+  }
+
+}

--- a/src/app/api/services/requirement-set.service.ts
+++ b/src/app/api/services/requirement-set.service.ts
@@ -5,7 +5,6 @@ import API_URL from 'src/app/config/constants/apiURL';
 
 @Injectable()
 export class RequirementSet {
-
   constructor(private http: HttpClient) {}
 
   private baseUrl: string = `${API_URL}/requirementset`;

--- a/src/app/api/services/unit-definition.service.ts
+++ b/src/app/api/services/unit-definition.service.ts
@@ -1,36 +1,31 @@
-import { TeachingPeriodService, Unit, UnitRole, UnitService, UserService } from 'src/app/api/models/doubtfire-model';
-import { CachedEntityService } from 'ngx-entity-service';
-import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import {UnitDefinition} from 'src/app/api/models/doubtfire-model';
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {HttpClient, HttpParams} from '@angular/common/http';
 
 import API_URL from 'src/app/config/constants/apiURL';
 
-@ Injectable()
-export class EntityService {
-  constructor() {}
-}
-
-@ Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class UnitDefinitionService {
 
   constructor(private http: HttpClient) {}
 
-  private baseUrl: string = `${API_URL}/unit-definition`;
-
+  private baseUrl: string = `${API_URL}/unit_definition`;
 
   // Get unit-definitions
-  getDefinitions(): Observable<Unit> {
-    const url = `${this.baseUrl}`;
-    return this.http.get<Unit>(url);
+  getDefinitions(): Observable<UnitDefinition[]> {
+    console.log("fetched unit definitions");
+    return this.http.get<UnitDefinition[]>(this.baseUrl);
   }
 
-  getUnitDefinitionById(): Observable<Unit> {
-    const url = `${this.baseUrl}/:id:`;
-    return this.http.get<Unit>(url);
+  getUnitDefinitionById(id: string): Observable<UnitDefinition> {
+    const url = `${this.baseUrl}/unitDefinitionId/${id}`;
+    return this.http.get<UnitDefinition>(url);
   }
 
-  searchUnitDefinitions(searchId?:number, searchName?: string, ): Observable<[]> {
+  searchUnitDefinitions(searchId?:number, searchName?: string, ): Observable<[UnitDefinition]> {
     let params = new HttpParams();
     if (searchId) {
       params = params.set('id', searchId.toString());
@@ -38,25 +33,22 @@ export class UnitDefinitionService {
     if (searchName) {
       params = params.set('name', searchName);
     }
-
-    const url = `${this.baseUrl}/search`;
-    return this.http.get<[]>(url, {params});
+    return this.http.get<[UnitDefinition]>(this.baseUrl, {params});
   }
 
   addUnitDefinition(
-    unitDefinitionId: number,
     name: string,
     description: string,
     code: string,
-  ): Observable<Unit> {
+    version: string,
+  ): Observable<UnitDefinition> {
     let params = new HttpParams();
-    params.set('unitDefinitionId', unitDefinitionId.toString());
     params.set('name', name);
     params.set('description', description);
     params.set('code', code);
-
-    const url = `${this.baseUrl}`;
-    return this.http.post<Unit>(url, {params});
+    params.set('version', version);
+    console.log("added unit definition");
+    return this.http.post<UnitDefinition>(this.baseUrl, {params});
   }
 
   updateUnitDefinition(
@@ -64,7 +56,7 @@ export class UnitDefinitionService {
     name: string,
     description: string,
     code: string,
-  ): Observable<Unit> {
+  ): Observable<UnitDefinition> {
     const params = new HttpParams();
     params.set('unitDefinitionId', unitDefinitionId.toString());
     params.set('name', name);
@@ -72,7 +64,7 @@ export class UnitDefinitionService {
     params.set('code', code);
 
     const url = `${this.baseUrl}/:id:`;
-    return this.http.put<Unit>(url, {params});
+    return this.http.put<UnitDefinition>(url, {params});
   }
 
   deleteUnitDefinition(unitId:number): Observable<void> {

--- a/src/app/api/services/unit-definition.service.ts
+++ b/src/app/api/services/unit-definition.service.ts
@@ -9,7 +9,6 @@ import API_URL from 'src/app/config/constants/apiURL';
   providedIn: 'root'
 })
 export class UnitDefinitionService {
-
   constructor(private http: HttpClient) {}
 
   private baseUrl: string = `${API_URL}/unit_definition`;

--- a/src/app/api/services/unit-definition.service.ts
+++ b/src/app/api/services/unit-definition.service.ts
@@ -1,0 +1,92 @@
+import { TeachingPeriodService, Unit, UnitRole, UnitService, UserService } from 'src/app/api/models/doubtfire-model';
+import { CachedEntityService } from 'ngx-entity-service';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient, HttpParams } from '@angular/common/http';
+
+import API_URL from 'src/app/config/constants/apiURL';
+
+@ Injectable()
+export class EntityService {
+  constructor() {}
+}
+
+@ Injectable()
+export class UnitDefinitionService {
+
+  constructor(private http: HttpClient) {}
+
+  private baseUrl: string = `${API_URL}/unit-definition`;
+
+
+  // Get unit-definitions
+  getDefinitions(): Observable<Unit> {
+    const url = `${this.baseUrl}`;
+    return this.http.get<Unit>(url);
+  }
+
+  getUnitDefinitionById(): Observable<Unit> {
+    const url = `${this.baseUrl}/:id:`;
+    return this.http.get<Unit>(url);
+  }
+
+  searchUnitDefinitions(searchId?:number, searchName?: string, ): Observable<[]> {
+    let params = new HttpParams();
+    if (searchId) {
+      params = params.set('id', searchId.toString());
+    }
+    if (searchName) {
+      params = params.set('name', searchName);
+    }
+
+    const url = `${this.baseUrl}/search`;
+    return this.http.get<[]>(url, {params});
+  }
+
+  addUnitDefinition(
+    unitDefinitionId: number,
+    name: string,
+    description: string,
+    code: string,
+  ): Observable<Unit> {
+    let params = new HttpParams();
+    params.set('unitDefinitionId', unitDefinitionId.toString());
+    params.set('name', name);
+    params.set('description', description);
+    params.set('code', code);
+
+    const url = `${this.baseUrl}`;
+    return this.http.post<Unit>(url, {params});
+  }
+
+  updateUnitDefinition(
+    unitDefinitionId: number,
+    name: string,
+    description: string,
+    code: string,
+  ): Observable<Unit> {
+    const params = new HttpParams();
+    params.set('unitDefinitionId', unitDefinitionId.toString());
+    params.set('name', name);
+    params.set('description', description);
+    params.set('code', code);
+
+    const url = `${this.baseUrl}/:id:`;
+    return this.http.put<Unit>(url, {params});
+  }
+
+  deleteUnitDefinition(unitId:number): Observable<void> {
+    const params = new HttpParams();
+    const url = `${this.baseUrl}/:id:`;
+    params.set('unitId', unitId.toString());
+    return this.http.delete<void>(url, {params});
+  }
+
+  removeUnitFromUnitDefinition(unitId:number, unitDefinitionId:number): Observable<void> {
+    const params = new HttpParams();
+    const url = `${this.baseUrl}/:id:`;
+    params.set('unitId', unitId.toString());
+    params.set('unitDefinitionId', unitDefinitionId.toString());
+    return this.http.delete<void>(url, {params});
+  }
+}

--- a/src/app/api/services/unit-definition.service.ts
+++ b/src/app/api/services/unit-definition.service.ts
@@ -32,7 +32,8 @@ export class UnitDefinitionService {
     if (searchName) {
       params = params.set('name', searchName);
     }
-    return this.http.get<[UnitDefinition]>(this.baseUrl, {params});
+    const url = `${this.baseUrl}/search`;
+    return this.http.get<[UnitDefinition]>(url, {params});
   }
 
   addUnitDefinition(

--- a/src/app/api/services/unit.service.ts
+++ b/src/app/api/services/unit.service.ts
@@ -24,7 +24,7 @@ export class UnitService extends CachedEntityService<Unit> {
   public readonly rolloverEndpoint = 'units/:id:/rollover';
 
   constructor(
-    httpClient: HttpClient,
+    private http: HttpClient,
     private teachingPeriodService: TeachingPeriodService,
     private tutorialService: TutorialService,
     private tutorialStreamService: TutorialStreamService,
@@ -34,7 +34,7 @@ export class UnitService extends CachedEntityService<Unit> {
     private groupSetService: GroupSetService,
     private groupService: GroupService
   ) {
-    super(httpClient, API_URL);
+    super(http, API_URL);
 
     this.cacheBehaviourOnGet = 'cacheQuery';
 
@@ -277,4 +277,15 @@ export class UnitService extends CachedEntityService<Unit> {
 
     return httpClient.get<any>(url);
   }
+
+  getUnitByCode(unitCode: string): Observable<Unit> {
+    const url = `${API_URL}/units/${unitCode}`;
+    return this.http.get<Unit>(url);
+  }
+
+  getUnits(): Observable<Unit[]> {
+    const url = `${API_URL}/units/`;
+    return this.http.get<Unit[]>(url);
+  }
+
 }

--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -77,6 +77,10 @@
         <mat-icon matListItemIcon aria-label="Edit calendar">calendar_month</mat-icon>
         Calendar
       </button>
+      <button mat-menu-item uiSref="coursemap">
+        <mat-icon matListItemIcon aria-label="Course Flow">directions</mat-icon>
+        CourseFlow
+      </button>
       <button mat-menu-item (click)="openAboutModal()">
         <mat-icon matListItemIcon aria-label="About">info</mat-icon>
         About

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -1,38 +1,71 @@
-<div class="container">
-  <h2>To Do</h2>
-  <div
-    cdkDropList
-    #todoList="cdkDropList"
-    [cdkDropListData]="todo"
-    [cdkDropListConnectedTo]="[trimester1List, trimester2List]"
-    (cdkDropListDropped)="drop($event)"
-    class="list">
-    <div class="item" *ngFor="let item of todo" cdkDrag>{{item}}</div>
+<div class="coursemap">
+  <!-- Required Units Panel -->
+  <div class="to-do-container">
+    <h3>Required Units</h3>
+    <div
+      cdkDropList
+      [cdkDropListData]="requiredUnits"
+      (cdkDropListDropped)="drop($event)"
+      [cdkDropListConnectedTo]="connectedDropLists"
+      [id]="requiredUnits"
+    >
+      <div class="unit" *ngFor="let unit of requiredUnits" cdkDrag>
+        {{ unit }}
+      </div>
+    </div>
   </div>
-</div>
+  <!-- Study Periods Panel -->
+  <div class="study-periods">
+    <h3>Study Periods</h3>
+    <div *ngFor="let year of years; let i = index" class="year-container">
+      <h4>{{ year.year }}</h4>
+      <!-- Trimester 1 -->
+      <div
+        class="trimester-list"
+        cdkDropList
+        [cdkDropListData]="year.trimester1"
+        (cdkDropListDropped)="drop($event)"
+        [cdkDropListConnectedTo]="connectedDropLists"
+        [id]="'trimester1-' + i"
+      >
+        <h5 class="trimester-heading">Trimester 1</h5>
+        <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
+          {{ unit }}
+        </div>
+      </div>
+      <!-- Trimester 2 -->
+      <div
+        class="trimester-list"
+        cdkDropList
+        [cdkDropListData]="year.trimester2"
+        (cdkDropListDropped)="drop($event)"
+        [cdkDropListConnectedTo]="connectedDropLists"
+        [id]="'trimester2-' + i"
+      >
+        <h5 class="trimester-heading">Trimester 2</h5>
+        <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
+          {{ unit }}
+        </div>
 
-<div class="container">
-  <h2>Trimester 1</h2>
-  <div
-    cdkDropList
-    #trimester1List="cdkDropList"
-    [cdkDropListData]="trimester1"
-    [cdkDropListConnectedTo]="[todoList, trimester2List]"
-    (cdkDropListDropped)="drop($event)"
-    class="list">
-    <div class="item" *ngFor="let item of trimester1" cdkDrag>{{item}}</div>
-  </div>
-</div>
-
-<div class="container">
-  <h2>Trimester 2</h2>
-  <div
-    cdkDropList
-    #trimester2List="cdkDropList"
-    [cdkDropListData]="trimester2"
-    [cdkDropListConnectedTo]="[todoList, trimester1List]"
-    (cdkDropListDropped)="drop($event)"
-    class="list">
-    <div class="item" *ngFor="let item of trimester2" cdkDrag>{{item}}</div>
+      </div>
+      <!-- Trimester 3 -->
+      <div
+        cdkDropList
+        class="trimester-list"
+        [cdkDropListData]="year.trimester3"
+        (cdkDropListDropped)="drop($event)"
+        [cdkDropListConnectedTo]="connectedDropLists"
+        [id]="'trimester3-' + i"
+      >
+        <h5 class="trimester-heading">Trimester 3</h5>
+        <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
+          {{ unit }}
+        </div>
+      </div>
+      <button mat-icon-button (click)="deleteYear(i)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </div>
+    <button (click)="addYear()">Add Year</button>
   </div>
 </div>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -1,13 +1,15 @@
 <div class="coursemap">
   <!-- Required Units Panel -->
-  <div class="to-do-container">
-    <h3>Required Units</h3>
+  <div class="required-units-container">
+    <div class="required-units-header">
+      <h3 class="required-units-title">Required Units</h3>
+    </div>
     <div
       cdkDropList
       [cdkDropListData]="requiredUnits"
       (cdkDropListDropped)="drop($event)"
       [cdkDropListConnectedTo]="connectedDropLists"
-      [id]="requiredUnits"
+      [id]="'requiredUnits'"
     >
       <div class="unit" *ngFor="let unit of requiredUnits" cdkDrag>
         {{ unit }}
@@ -15,12 +17,21 @@
     </div>
   </div>
   <!-- Study Periods Panel -->
-  <div class="study-periods">
-    <h3>Study Periods</h3>
+  <div class="study-periods-container">
+    <div class="study-periods-header">
+      <h3 class="study-periods-title">Study Periods</h3>
+    </div>
+    <!-- Year Container -->
     <div *ngFor="let year of years; let i = index" class="year-container">
-      <h4>{{ year.year }}</h4>
+      <div class="year-header">
+        <h3 class="year-title">{{ year.year }}</h3>
+        <button class="delete-button" mat-icon-button (click)="deleteYear(i)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
       <!-- Trimester 1 -->
       <div
+        *ngIf="year.trimester1"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester1"
@@ -29,12 +40,17 @@
         [id]="'trimester1-' + i"
       >
         <h5 class="trimester-heading">Trimester 1</h5>
+
         <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
           {{ unit }}
         </div>
+        <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 0)">
+          <mat-icon>delete</mat-icon>
+        </button>
       </div>
       <!-- Trimester 2 -->
       <div
+      *ngIf="year.trimester2"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester2"
@@ -43,13 +59,17 @@
         [id]="'trimester2-' + i"
       >
         <h5 class="trimester-heading">Trimester 2</h5>
+
         <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
           {{ unit }}
         </div>
-
+        <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 1)">
+          <mat-icon>delete</mat-icon>
+        </button>
       </div>
       <!-- Trimester 3 -->
       <div
+      *ngIf="year.trimester3"
         cdkDropList
         class="trimester-list"
         [cdkDropListData]="year.trimester3"
@@ -58,14 +78,20 @@
         [id]="'trimester3-' + i"
       >
         <h5 class="trimester-heading">Trimester 3</h5>
+
         <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
           {{ unit }}
         </div>
+        <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 2)">
+          <mat-icon>delete</mat-icon>
+        </button>
       </div>
-      <button mat-icon-button (click)="deleteYear(i)">
-        <mat-icon>delete</mat-icon>
+      <button mat-icon-button *ngIf="countTrimesters(year) < 3" (click)="addTrimester(i)">
+        <mat-icon>add_circle_outline</mat-icon>
       </button>
     </div>
-    <button (click)="addYear()">Add Year</button>
+    <button (click)="addYear()" mat-icon-button>
+      <mat-icon>add_circle_outline</mat-icon>
+    </button>
   </div>
 </div>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -17,6 +17,8 @@
     </div>
     <div class="electives-container">
       <h3 class="electives-title">Elective Units</h3>
+      <p>Electives remaining: {{ remainingSlots }} of {{ maxElectiveUnits }}</p>
+
       <div
         *ngIf="electiveUnits"
         cdkDropList
@@ -31,17 +33,19 @@
           </p>
         </div>
       </div>
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>Enter Unit Code</mat-label>
-          <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode" />
-        </mat-form-field>
-        <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
+      <form (ngSubmit)="fetchUnitByCode()">
+        <div>
+          <mat-form-field appearance="fill">
+            <mat-label>Enter Unit Code</mat-label>
+            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode" />
+          </mat-form-field>
+          <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
 
-        <div *ngIf="errorMessage" class="error">
-          {{ errorMessage }}
+          <div *ngIf="errorMessage" class="error">
+            {{ errorMessage }}
+          </div>
         </div>
-      </div>
+      </form>
     </div>
   </div>
   <!-- Study Periods Panel -->

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -12,7 +12,35 @@
       [id]="'requiredUnits'"
     >
       <div class="unit" *ngFor="let unit of requiredUnits" cdkDrag>
-        {{ unit }}
+        <strong>{{ unit.code }}</strong> - {{ unit.name }}
+      </div>
+    </div>
+    <div class="electives-container">
+      <h3 class="electives-title">Elective Units</h3>
+      <div
+        *ngIf="electiveUnits"
+        cdkDropList
+        [cdkDropListData]="electiveUnits"
+        (cdkDropListDropped)="drop($event)"
+        [cdkDropListConnectedTo]="connectedDropLists"
+        [id]="electiveUnits"
+      >
+        <div *ngFor="let unit of electiveUnits" cdkDrag class="unit">
+          <p>
+            <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          </p>
+        </div>
+      </div>
+      <div>
+        <mat-form-field appearance="fill">
+          <mat-label>Enter Unit Code</mat-label>
+          <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode" />
+        </mat-form-field>
+        <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
+
+        <div *ngIf="errorMessage" class="error">
+          {{ errorMessage }}
+        </div>
       </div>
     </div>
   </div>
@@ -42,7 +70,7 @@
         <h5 class="trimester-heading">Trimester 1</h5>
 
         <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
-          {{ unit }}
+          <strong>{{ unit.code }}</strong> - {{ unit.name }}
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 0)">
           <mat-icon>delete</mat-icon>
@@ -61,7 +89,7 @@
         <h5 class="trimester-heading">Trimester 2</h5>
 
         <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
-          {{ unit }}
+          <strong>{{ unit.code }}</strong> - {{ unit.name }}
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 1)">
           <mat-icon>delete</mat-icon>
@@ -80,7 +108,7 @@
         <h5 class="trimester-heading">Trimester 3</h5>
 
         <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
-          {{ unit }}
+          <strong>{{ unit.code }}</strong> - {{ unit.name }}
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 2)">
           <mat-icon>delete</mat-icon>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -62,7 +62,7 @@
       </div>
       <!-- Trimester 1 -->
       <div
-        *ngIf="year.trimester1"
+      *ngIf="year.trimester1"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester1"

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -17,8 +17,7 @@
     </div>
     <div class="electives-container">
       <h3 class="electives-title">Elective Units</h3>
-      <p>Electives remaining: {{ remainingSlots }} of {{ maxElectiveUnits }}</p>
-
+      <p class="text">Electives remaining: {{ remainingSlots }} of {{ maxElectiveUnits }}</p>
       <div
         *ngIf="electiveUnits"
         cdkDropList
@@ -27,13 +26,13 @@
         [cdkDropListConnectedTo]="connectedDropLists"
         [id]="electiveUnits"
       >
-        <div *ngFor="let unit of electiveUnits" cdkDrag class="unit">
-          <p>
+        <div class="text" *ngFor="let unit of electiveUnits" cdkDrag class="unit">
+          <p >
             <strong>{{ unit.code }}</strong> - {{ unit.name }}
           </p>
         </div>
       </div>
-      <form (ngSubmit)="fetchUnitByCode()">
+      <form class="form" (ngSubmit)="fetchUnitByCode()">
         <div>
           <mat-form-field appearance="fill">
             <mat-label>Enter Unit Code</mat-label>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -1,0 +1,3 @@
+<section class="welcome" fxFlex fxLayout="row">
+  <h1>Welcome to courseflow</h1>
+</section>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -1,3 +1,38 @@
-<section class="welcome" fxFlex fxLayout="row">
-  <h1>Welcome to courseflow</h1>
-</section>
+<div class="container">
+  <h2>To Do</h2>
+  <div
+    cdkDropList
+    #todoList="cdkDropList"
+    [cdkDropListData]="todo"
+    [cdkDropListConnectedTo]="[trimester1List, trimester2List]"
+    (cdkDropListDropped)="drop($event)"
+    class="list">
+    <div class="item" *ngFor="let item of todo" cdkDrag>{{item}}</div>
+  </div>
+</div>
+
+<div class="container">
+  <h2>Trimester 1</h2>
+  <div
+    cdkDropList
+    #trimester1List="cdkDropList"
+    [cdkDropListData]="trimester1"
+    [cdkDropListConnectedTo]="[todoList, trimester2List]"
+    (cdkDropListDropped)="drop($event)"
+    class="list">
+    <div class="item" *ngFor="let item of trimester1" cdkDrag>{{item}}</div>
+  </div>
+</div>
+
+<div class="container">
+  <h2>Trimester 2</h2>
+  <div
+    cdkDropList
+    #trimester2List="cdkDropList"
+    [cdkDropListData]="trimester2"
+    [cdkDropListConnectedTo]="[todoList, trimester1List]"
+    (cdkDropListDropped)="drop($event)"
+    class="list">
+    <div class="item" *ngFor="let item of trimester2" cdkDrag>{{item}}</div>
+  </div>
+</div>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -36,7 +36,7 @@
         <div>
           <mat-form-field appearance="fill">
             <mat-label>Enter Unit Code</mat-label>
-            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode" />
+            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode"/>
           </mat-form-field>
           <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
 

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -27,7 +27,7 @@
         [id]="electiveUnits"
       >
         <div class="text" *ngFor="let unit of electiveUnits" cdkDrag class="unit">
-          <p >
+          <p>
             <strong>{{ unit.code }}</strong> - {{ unit.name }}
           </p>
         </div>
@@ -36,7 +36,13 @@
         <div>
           <mat-form-field appearance="fill">
             <mat-label>Enter Unit Code</mat-label>
-            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode"/>
+            <input
+              class="search-bar"
+              matInput
+              [(ngModel)]="unitCode"
+              name="unitCode"
+              id="unitCode"
+            />
           </mat-form-field>
           <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
 
@@ -62,7 +68,7 @@
       </div>
       <!-- Trimester 1 -->
       <div
-      *ngIf="year.trimester1"
+        *ngIf="year.trimester1"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester1"
@@ -72,8 +78,18 @@
       >
         <h5 class="trimester-heading">Trimester 1</h5>
 
-        <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester1"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 0)">
           <mat-icon>delete</mat-icon>
@@ -81,7 +97,7 @@
       </div>
       <!-- Trimester 2 -->
       <div
-      *ngIf="year.trimester2"
+        *ngIf="year.trimester2"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester2"
@@ -91,8 +107,18 @@
       >
         <h5 class="trimester-heading">Trimester 2</h5>
 
-        <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester2"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 1)">
           <mat-icon>delete</mat-icon>
@@ -100,7 +126,7 @@
       </div>
       <!-- Trimester 3 -->
       <div
-      *ngIf="year.trimester3"
+        *ngIf="year.trimester3"
         cdkDropList
         class="trimester-list"
         [cdkDropListData]="year.trimester3"
@@ -110,8 +136,18 @@
       >
         <h5 class="trimester-heading">Trimester 3</h5>
 
-        <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester3"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 2)">
           <mat-icon>delete</mat-icon>

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,22 +1,58 @@
-.container {
+.to-do-container {
   margin: 16px;
   padding: 16px;
   border: 1px solid #ccc;
   border-radius: 4px;
   display: inline-block;
-  width: 200px;
+  width: 30vw;
   vertical-align: top;
 }
 
-.list {
-  min-height: 100px;
+.year-container {
+  margin: 16px;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: flex;
+  width: 60vw;
+  vertical-align: top;
+  flex-direction: column;
 }
 
-.item {
+.trimester-list {
+  display: flex;
+  flex-direction: row; /* Makes the items within the list display horizontally */
+  padding: 10px;
+  border-radius: 4px;
+  background-color: rgb(238, 238, 238);
+  margin: 10px;
+  align-items: center;
+}
+
+.unit {
   padding: 8px;
-  margin-bottom: 4px;
+  margin: 4px;
   background-color: #f1f1f1;
   border: 1px solid #ddd;
   border-radius: 4px;
   cursor: move;
+  align-content: center;
 }
+
+.study-periods {
+  display: flex;
+  flex-direction: column;
+}
+
+.coursemap {
+  display: flex;
+  flex-direction: row;
+}
+
+
+.trimester-heading {
+  margin-right: 20px;
+  align-items: center;
+}
+
+

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,0 +1,22 @@
+.container {
+  margin: 16px;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: inline-block;
+  width: 200px;
+  vertical-align: top;
+}
+
+.list {
+  min-height: 100px;
+}
+
+.item {
+  padding: 8px;
+  margin-bottom: 4px;
+  background-color: #f1f1f1;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: move;
+}

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,8 +1,6 @@
-.to-do-container {
-  margin: 16px;
-  padding: 16px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+.required-units-container {
+  border: 1px solid #337ab7;
+  border-radius: 6px;
   display: inline-block;
   width: 30vw;
   vertical-align: top;
@@ -10,20 +8,21 @@
 
 .year-container {
   margin: 16px;
-  padding: 16px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  border: 1px solid #337ab7;
+  border-radius: 9px;
   display: flex;
-  width: 60vw;
+  width: 90%;
   vertical-align: top;
   flex-direction: column;
+  border-radius: 6px;
+  width: auto;
 }
 
 .trimester-list {
   display: flex;
   flex-direction: row; /* Makes the items within the list display horizontally */
   padding: 10px;
-  border-radius: 4px;
+  border-radius: 6px;
   background-color: rgb(238, 238, 238);
   margin: 10px;
   align-items: center;
@@ -31,17 +30,37 @@
 
 .unit {
   padding: 8px;
-  margin: 4px;
-  background-color: #f1f1f1;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  margin: 16px;
+  background-color: #357bb9a8;
+  color: white;
+  border-radius: 6px;
   cursor: move;
   align-content: center;
+  height: 40px;
+
 }
 
-.study-periods {
+.study-periods-container {
   display: flex;
   flex-direction: column;
+  border: 1px solid #337ab7;
+  border-radius: 6px;
+  margin-left: 20px;
+  width: 70vw;
+}
+
+.study-periods-header, .required-units-header, .year-header{
+  background-color: #337ab7;
+  border-radius: 5px 5px 0 0;
+  color: white;
+  height: 40px;
+  align-items: center;
+  display: flex;
+  padding: 0 10px;
+}
+
+.study-periods-title, .required-units-title, .year-title {
+  margin: 0 2% 0 0;
 }
 
 .coursemap {
@@ -49,10 +68,14 @@
   flex-direction: row;
 }
 
-
 .trimester-heading {
   margin-right: 20px;
   align-items: center;
+}
+
+.delete-button {
+  margin-left: auto;
+  right: 2%;
 }
 
 

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -121,8 +121,6 @@ mat-form-field {
   flex-shrink: 1;
 }
 
-
-
 @media only screen and (max-width: 775px) {
   .study-periods-title, .required-units-title, .year-title, .electives-title {
     font-size: 2.7vw;

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,10 +1,13 @@
 .required-units-container {
   border: 1px solid #337ab7;
   border-radius: 6px;
-  display: inline-block;
-  width: 30vw;
+  display: flex;
+  height: 80vh;
   vertical-align: top;
-  align-items: center;
+  align-items: left;
+  flex-direction: column;
+  width: 100%; /* Fill available space on mobile */
+  max-width: 25vw;
 }
 
 .year-container {
@@ -33,14 +36,14 @@
 
 .unit {
   padding: 8px;
-  margin: 16px;
+  margin: 8px 0 8px 5%;
   background-color: #357bb9a8;
   color: white;
   border-radius: 6px;
   cursor: move;
   align-content: center;
-  height: 40px;
-  width: 95%;
+  height: 8vh;
+  width: 90%;
 }
 
 .study-periods-container {
@@ -62,9 +65,11 @@
   display: flex;
   padding: 0 10px;
   width: 100%;
+  font-size: 1.2rem; /* Adjust to ensure readability on smaller screens */
 }
 
 .study-periods-title, .required-units-title, .year-title, .electives-title {
+  font-size: 2rem; /* Default font size for larger screens */
   margin: 0 2%;
 }
 
@@ -73,14 +78,15 @@
 }
 
 .text {
-  margin-left: 2%;
+  margin: auto 2% auto 2%;
 }
 
 .electives-container {
   width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
+  margin: auto 0 8px 5%;
 }
 
 mat-form-field {
@@ -111,6 +117,28 @@ mat-form-field {
 .delete-button {
   margin-left: auto;
   right: 2%;
+  display: flex;
+  flex-shrink: 1;
 }
+
+
+
+@media only screen and (max-width: 775px) {
+  .study-periods-title, .required-units-title, .year-title, .electives-title {
+    font-size: 2.7vw;
+  }
+
+  .text {
+    margin: auto 2% auto 2%;
+    font-size: 1.7vw;
+  }
+
+  .unit {
+    font-size: 1.65vw;
+  }
+
+
+}
+
 
 

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -37,7 +37,6 @@
   cursor: move;
   align-content: center;
   height: 40px;
-
 }
 
 .study-periods-container {
@@ -61,6 +60,24 @@
 
 .study-periods-title, .required-units-title, .year-title {
   margin: 0 2% 0 0;
+}
+
+.electives-container {
+  margin: 0 3% 0 3%;
+}
+
+mat-form-field {
+  width: 75%;
+}
+
+.search-bar {
+  margin: 0 1% 0 1%;
+  width: 70%;
+}
+
+.button {
+  border-radius: 5px;
+  margin: 0 2% 0 2%;
 }
 
 .coursemap {

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -4,6 +4,7 @@
   display: inline-block;
   width: 30vw;
   vertical-align: top;
+  align-items: center;
 }
 
 .year-container {
@@ -15,7 +16,10 @@
   vertical-align: top;
   flex-direction: column;
   border-radius: 6px;
-  width: auto;
+  width: 98%;
+  justify-content: center;
+  align-items: center;
+
 }
 
 .trimester-list {
@@ -26,6 +30,7 @@
   background-color: rgb(238, 238, 238);
   margin: 10px;
   align-items: center;
+  width: 95%;
 }
 
 .unit {
@@ -46,6 +51,7 @@
   border-radius: 6px;
   margin-left: 20px;
   width: 70vw;
+  align-items: center;
 }
 
 .study-periods-header, .required-units-header, .year-header{
@@ -56,6 +62,7 @@
   align-items: center;
   display: flex;
   padding: 0 10px;
+  width: 100%;
 }
 
 .study-periods-title, .required-units-title, .year-title {
@@ -77,7 +84,7 @@ mat-form-field {
 
 .button {
   border-radius: 5px;
-  margin: 0 2% 0 2%;
+  margin: 0 2% 2% 2%;
 }
 
 .coursemap {

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -12,14 +12,12 @@
   border: 1px solid #337ab7;
   border-radius: 9px;
   display: flex;
-  width: 90%;
   vertical-align: top;
   flex-direction: column;
   border-radius: 6px;
   width: 98%;
   justify-content: center;
   align-items: center;
-
 }
 
 .trimester-list {
@@ -42,6 +40,7 @@
   cursor: move;
   align-content: center;
   height: 40px;
+  width: 95%;
 }
 
 .study-periods-container {
@@ -65,16 +64,28 @@
   width: 100%;
 }
 
-.study-periods-title, .required-units-title, .year-title {
-  margin: 0 2% 0 0;
+.study-periods-title, .required-units-title, .year-title, .electives-title {
+  margin: 0 2%;
+}
+
+.form {
+  margin: 0 2%;
+}
+
+.text {
+  margin-left: 2%;
 }
 
 .electives-container {
-  margin: 0 3% 0 3%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 mat-form-field {
   width: 75%;
+
 }
 
 .search-bar {

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,142 +1,165 @@
-.required-units-container {
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  display: flex;
-  height: 80vh;
-  vertical-align: top;
-  align-items: left;
-  flex-direction: column;
-  width: 100%; /* Fill available space on mobile */
-  max-width: 25vw;
-}
-
-.year-container {
-  margin: 16px;
-  border: 1px solid #337ab7;
-  border-radius: 9px;
-  display: flex;
-  vertical-align: top;
-  flex-direction: column;
-  border-radius: 6px;
-  width: 98%;
-  justify-content: center;
-  align-items: center;
-}
-
-.trimester-list {
-  display: flex;
-  flex-direction: row; /* Makes the items within the list display horizontally */
-  padding: 10px;
-  border-radius: 6px;
-  background-color: rgb(238, 238, 238);
-  margin: 10px;
-  align-items: center;
-  width: 95%;
-}
-
-.unit {
-  padding: 8px;
-  margin: 8px 0 8px 5%;
-  background-color: #357bb9a8;
-  color: white;
-  border-radius: 6px;
-  cursor: move;
-  align-content: center;
-  height: 8vh;
-  width: 90%;
-}
-
-.study-periods-container {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  margin-left: 20px;
-  width: 70vw;
-  align-items: center;
-}
-
-.study-periods-header, .required-units-header, .year-header{
-  background-color: #337ab7;
-  border-radius: 5px 5px 0 0;
-  color: white;
-  height: 40px;
-  align-items: center;
-  display: flex;
-  padding: 0 10px;
-  width: 100%;
-  font-size: 1.2rem; /* Adjust to ensure readability on smaller screens */
-}
-
-.study-periods-title, .required-units-title, .year-title, .electives-title {
-  font-size: 2rem; /* Default font size for larger screens */
-  margin: 0 2%;
-}
-
-.form {
-  margin: 0 2%;
-}
-
-.text {
-  margin: auto 2% auto 2%;
-}
-
-.electives-container {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  margin: auto 0 8px 5%;
-}
-
-mat-form-field {
-  width: 75%;
-
-}
-
-.search-bar {
-  margin: 0 1% 0 1%;
-  width: 70%;
-}
-
-.button {
-  border-radius: 5px;
-  margin: 0 2% 2% 2%;
-}
-
 .coursemap {
   display: flex;
   flex-direction: row;
+  gap: 20px;
+  width: 80%;
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+  max-height: 90vh;
+}
+
+/* Required Units Panel */
+.required-units-container {
+  width: 25%;
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.completed {
+  text-decoration: line-through;
+  color: grey;
+}
+
+.required-units-title, .electives-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.unit {
+  background: #e3e7ed;
+  padding: 10px;
+  margin: 5px 0;
+  border-radius: 5px;
+  cursor: grab;
+  transition: background 0.3s;
+}
+
+.unit-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.complete-checkbox {
+  margin-left: auto; /* Ensure the checkbox stays on the far right */
+  cursor: pointer;
+}
+
+.unit:hover {
+  background: #d0d4db;
+}
+
+.search-bar {
+  width: 100%;
+  padding: 8px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+.button {
+  margin-top: 10px;
+  width: 100%;
+  background-color: #007bff;
+  color: white;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: #0056b3;
+}
+
+/* Study Periods Panel */
+.study-periods-container {
+  width: 70%;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.year-container {
+  background: #f9fafc;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.year-title {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.trimester-list {
+  background: #eef1f6;
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .trimester-heading {
-  margin-right: 20px;
-  align-items: center;
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .delete-button {
-  margin-left: auto;
-  right: 2%;
-  display: flex;
-  flex-shrink: 1;
+  background: none;
+  border: none;
+  color: red;
+  cursor: pointer;
 }
 
-@media only screen and (max-width: 775px) {
-  .study-periods-title, .required-units-title, .year-title, .electives-title {
-    font-size: 2.7vw;
-  }
-
-  .text {
-    margin: auto 2% auto 2%;
-    font-size: 1.7vw;
-  }
-
-  .unit {
-    font-size: 1.65vw;
-  }
-
-
+.add-button {
+  display: block;
+  width: 100%;
+  background: #28a745;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  margin-top: 10px;
 }
 
+.add-button:hover {
+  background: #218838;
+}
 
+.completed {
+  text-decoration: line-through;
+  color: grey;
+  opacity: 0.7;
+  cursor: pointer;
+}
 
+.checkmark {
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.inactive {
+  color: lightgray;
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .coursemap {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .required-units-container, .study-periods-container {
+    width: 100%;
+  }
+}

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -14,12 +14,11 @@ import {GlobalStateService} from 'src/app/projects/states/index/global-state.ser
 import {UnitService} from 'src/app/api/services/unit.service';
 import {Unit} from 'src/app/api/models/doubtfire-model';
 import {FormsModule} from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-
-
-
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatButtonModule} from '@angular/material/button';
+import {Course} from 'src/app/api/models/doubtfire-model';
+import {CourseService} from 'src/app/api/services/course.service';
 
 type signInData =
   | {
@@ -75,6 +74,16 @@ export class CoursemapComponent implements OnInit {
     {code: 'SIT5', name: 'Mobile App Development'},
     {code: 'SIT6', name: 'Software Engineering'},
   ]
+  courses: Course[] = [];
+
+  testCourse: Course = {
+      id: '12345',
+      name: 'Introduction to Programming',
+      code: 'CS101',
+      year: 2024,
+      version: 'v1.0',
+      url: 'http://university.edu/courses/cs101'
+    };
 
 
   ngOnInit(): void {
@@ -94,6 +103,8 @@ export class CoursemapComponent implements OnInit {
         console.error('Error fetching units:', err);
       },
     });
+    this.getCourses();
+
   }
 
   years = [
@@ -181,7 +192,8 @@ export class CoursemapComponent implements OnInit {
     private transition: Transition,
     private globalState: GlobalStateService,
     private alerts: AlertService,
-    private unitService: UnitService
+    private unitService: UnitService,
+    private courseService: CourseService,
   ) {}
 
   drop(event: CdkDragDrop<string[]>) {
@@ -221,4 +233,28 @@ export class CoursemapComponent implements OnInit {
       this.unit = null;
     }
   }
+
+  loadCourses(): void {
+    this.courseService.getCourses().subscribe(
+      (data: Course[]) => {
+        this.courses = data;
+      },
+      error => {
+        console.error('Error fetching courses', error);
+      }
+    );
+  }
+
+  getCourses(): void {
+    this.courseService.getCourses().subscribe(
+      (data: Course[]) => {
+        this.courses = data;
+        console.log('Courses fetched successfully:', this.courses);
+      },
+      (error) => {
+        console.error('Error fetching courses:', error);
+      }
+    );
+  }
+
 }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -105,10 +105,15 @@ export class CoursemapComponent implements OnInit {
     },
   ];
 
+  maxElectiveUnits = 5;
+
   electiveUnits: Unit[] = [];
 
-
   allTrimesters = [this.years[0].trimester1, this.years[0].trimester2, this.years[0].trimester3];
+
+  get remainingSlots(): number {
+    return this.maxElectiveUnits - this.electiveUnits.length;
+  }
 
   get connectedDropLists(): string[] {
     const dropListIds: string[] = ['requiredUnits'];

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -19,6 +19,7 @@ import {MatInputModule} from '@angular/material/input';
 import {MatButtonModule} from '@angular/material/button';
 import {Course} from 'src/app/api/models/doubtfire-model';
 import {CourseService} from 'src/app/api/services/course.service';
+import { CourseMapService } from 'src/app/api/services/course-map.service';
 
 type signInData =
   | {
@@ -194,6 +195,7 @@ export class CoursemapComponent implements OnInit {
     private alerts: AlertService,
     private unitService: UnitService,
     private courseService: CourseService,
+    private courseMapService: CourseMapService,
   ) {}
 
   drop(event: CdkDragDrop<string[]>) {
@@ -234,17 +236,6 @@ export class CoursemapComponent implements OnInit {
     }
   }
 
-  loadCourses(): void {
-    this.courseService.getCourses().subscribe(
-      (data: Course[]) => {
-        this.courses = data;
-      },
-      error => {
-        console.error('Error fetching courses', error);
-      }
-    );
-  }
-
   getCourses(): void {
     this.courseService.getCourses().subscribe(
       (data: Course[]) => {
@@ -253,6 +244,17 @@ export class CoursemapComponent implements OnInit {
       },
       (error) => {
         console.error('Error fetching courses:', error);
+      }
+    );
+  }
+
+  addCourseMap(): void {
+    this.courseMapService.addCourseMap(1, 1).subscribe(
+      (data) => {
+        console.log('Course map added:', data);
+      },
+      (error) => {
+        console.error('Error adding course map:', error);
       }
     );
   }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -1,14 +1,36 @@
 import { Component, OnInit } from '@angular/core';
-import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+import { CdkDragDrop, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { MatListModule } from '@angular/material/list';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @Component({
-  selector: 'f-welcome',
+  selector: 'coursemap',
   templateUrl: './coursemap.component.html',
   styleUrls: ['./coursemap.component.scss'],
+  standalone: true,
+  imports: [CommonModule, MatListModule, DragDropModule],
 })
 export class CoursemapComponent implements OnInit {
-  constructor(private constants: DoubtfireConstants) {}
+
+  todo = ['Get to work', 'Pick up groceries', 'Go home', 'Fall asleep'];
+  trimester1 = ['Exercise', 'Study'];
+  trimester2 = ['Read a book'];
+
+  constructor() {}
+
   ngOnInit(): void {}
 
-  public externalName = this.constants.ExternalName;
+  drop(event: CdkDragDrop<string[]>) {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+    }
+  }
 }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -1,25 +1,55 @@
-import { Component, OnInit } from '@angular/core';
-import { CdkDragDrop, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
-import { CommonModule } from '@angular/common';
-import { MatListModule } from '@angular/material/list';
-import { DragDropModule } from '@angular/cdk/drag-drop';
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatListModule} from '@angular/material/list';
+import {DragDropModule} from '@angular/cdk/drag-drop';
+import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag-drop';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'coursemap',
   templateUrl: './coursemap.component.html',
   styleUrls: ['./coursemap.component.scss'],
   standalone: true,
-  imports: [CommonModule, MatListModule, DragDropModule],
+  imports: [CommonModule, MatListModule, DragDropModule, MatIconModule],
 })
-export class CoursemapComponent implements OnInit {
+export class CoursemapComponent {
+  requiredUnits = ['SIT1', 'SIT2', 'SIT3', 'SIT4', 'SIT5', 'SIT6'];
 
-  todo = ['Get to work', 'Pick up groceries', 'Go home', 'Fall asleep'];
-  trimester1 = ['Exercise', 'Study'];
-  trimester2 = ['Read a book'];
+  years = [
+    {
+      year: 2023,
+      trimester1: ['Course 1', 'Course 2'],
+      trimester2: ['Course 3', 'Course 4'],
+      trimester3: ['Course 5', 'Course 6'],
+    },
+  ];
+
+  allTrimesters = [this.years[0].trimester1, this.years[0].trimester2, this.years[0].trimester3];
+
+  get connectedDropLists(): string[] {
+    const dropListIds: string[] = ['requiredUnits'];
+    this.years.forEach((_, i) => {
+      dropListIds.push(`trimester1-${i}`, `trimester2-${i}`, `trimester3-${i}`);
+    });
+    return dropListIds;
+  }
+
+  addYear() {
+    const nextYear = this.years.length > 0 ? this.years[this.years.length - 1].year + 1 : new Date().getFullYear();
+    const newYear = {
+      year: nextYear,
+      trimester1: [],
+      trimester2: [],
+      trimester3: [],
+    };
+    this.years.push(newYear);
+  }
+
+  deleteYear(index: number) {
+    this.years.splice(index, 1);
+  }
 
   constructor() {}
-
-  ngOnInit(): void {}
 
   drop(event: CdkDragDrop<string[]>) {
     if (event.previousContainer === event.container) {
@@ -29,7 +59,7 @@ export class CoursemapComponent implements OnInit {
         event.previousContainer.data,
         event.container.data,
         event.previousIndex,
-        event.currentIndex
+        event.currentIndex,
       );
     }
   }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -203,7 +203,13 @@ export class CoursemapComponent implements OnInit {
       return;
     }
 
-    // Filter the units array by code
+    const alreadyAdded = this.electiveUnits.some(unit => unit.code === this.unitCode);
+
+    if (alreadyAdded) {
+      this.errorMessage = 'Unit already added';
+      return;
+    }
+
     const foundUnit = this.units.find(unit => unit.code === this.unitCode);
 
     if (foundUnit) {

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+
+@Component({
+  selector: 'f-welcome',
+  templateUrl: './coursemap.component.html',
+  styleUrls: ['./coursemap.component.scss'],
+})
+export class CoursemapComponent implements OnInit {
+  constructor(private constants: DoubtfireConstants) {}
+  ngOnInit(): void {}
+
+  public externalName = this.constants.ExternalName;
+}

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -49,6 +49,41 @@ export class CoursemapComponent {
     this.years.splice(index, 1);
   }
 
+  deleteTrimester(yearIndex: number, trimesterIndex: number) {
+    const trimesters = ['trimester1', 'trimester2', 'trimester3'];
+    const trimesterToDelete = this.years[yearIndex][trimesters[trimesterIndex]];
+
+    // Move all units from the trimester to the requiredUnits array
+    this.requiredUnits.push(...trimesterToDelete);
+
+    // Set the trimester to null to remove it
+    this.years[yearIndex][trimesters[trimesterIndex]] = null;
+  }
+
+  addTrimester(yearIndex: number) {
+    const year = this.years[yearIndex];
+
+    if (!year.trimester1) {
+      year.trimester1 = [];
+    } else if (!year.trimester2) {
+      year.trimester2 = [];
+    } else if (!year.trimester3) {
+      year.trimester3 = [];
+    } else {
+      // Optional: Alert or handle the case where all three trimesters already exist
+      console.log('All three trimesters already exist.');
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  countTrimesters(year: any): number {
+    let trimesterCount = 0;
+    if (year.trimester1 && year.trimester1.length > 0) trimesterCount++;
+    if (year.trimester2 && year.trimester2.length > 0) trimesterCount++;
+    if (year.trimester3 && year.trimester3.length > 0) trimesterCount++;
+    return trimesterCount;
+  }
+
   constructor() {}
 
   drop(event: CdkDragDrop<string[]>) {

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -92,13 +92,14 @@ export class CoursemapComponent implements OnInit {
   // Temporarily creating a course until database is populated with real data
   testCourse: Course = {
     id: '12345',
-    name: 'Introduction to Programming',
-    code: 'CS101',
+    name: 'Bachelor of Cyber Security',
+    code: 'S334',
     year: 2024,
     version: 'v1.0',
-    url: 'http://university.edu/courses/cs101',
+    url: 'http://example.com',
   };
 
+  completedUnits: Set<string> = new Set(); // Stores completed unit codes
 
   ngOnInit(): void {
     this.formData = {
@@ -123,7 +124,7 @@ export class CoursemapComponent implements OnInit {
     this.courseService.getCourses().subscribe({
       next: (data: Course[]) => {
         this.courses = data;
-        console.log('Courses:', this.courses); // Optional: Log the courses to verify
+        console.log('Courses:', this.testCourse); // Optional: Log the courses to verify
       },
       error: (err) => {
         this.errorMessage = 'Error fetching courses';
@@ -166,7 +167,7 @@ export class CoursemapComponent implements OnInit {
       },
     })
     //temporarily create coursemap with id of 1 until database is loaded
-    this.courseMapService.addCourseMap(1,1);
+    this.courseMapService.addCourseMap(1, 1);
     //add empty units to coursemap to initialise study periods
     this.courseMapUnitService.getCourseMapUnitsById(1).subscribe(
       (data: CourseMapUnit[]) => {
@@ -183,7 +184,7 @@ export class CoursemapComponent implements OnInit {
   populateYearsArray(courseMapUnits: CourseMapUnit[]) {
     this.years = [];
 
-    courseMapUnits.forEach(unit => {
+    courseMapUnits.forEach((unit) => {
       console.log('Processing unit with yearSlot:', unit.yearSlot); // Log the yearSlot value
 
       // Find the year object with the same yearSlot value
@@ -309,10 +310,21 @@ export class CoursemapComponent implements OnInit {
         event.previousIndex,
         event.currentIndex,
       );
-
-
     }
+  }
 
+  // Toggle completion state
+  toggleCompletion(unit: UnitDefinition) {
+    if (this.completedUnits.has(unit.code)) {
+      this.completedUnits.delete(unit.code);
+    } else {
+      this.completedUnits.add(unit.code);
+    }
+  }
+
+  // Check if a unit is completed
+  isCompleted(unit: UnitDefinition): boolean {
+    return this.completedUnits.has(unit.code);
   }
 
   fetchUnitByCode(): void {
@@ -339,5 +351,4 @@ export class CoursemapComponent implements OnInit {
       this.unit = null;
     }
   }
-
 }

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -207,6 +207,8 @@ import {UnitAnalyticsComponent} from './units/states/analytics/unit-analytics-ro
 import {FileDropComponent} from './common/file-drop/file-drop.component';
 import {UnitTaskEditorComponent} from './units/states/edit/directives/unit-tasks-editor/unit-task-editor.component';
 import {FUsersComponent} from './admin/states/f-users/f-users.component';
+import { CoursemapComponent } from './courseflow/coursemap/coursemap.component';
+
 
 import {CreateNewUnitModal} from './admin/modals/create-new-unit-modal/create-new-unit-modal.component';
 import {CreateNewUnitModalContentComponent} from './admin/modals/create-new-unit-modal/create-new-unit-modal-content.component';

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -8,6 +8,7 @@ import {TeachingPeriodListComponent} from './admin/states/teaching-periods/teach
 import {AcceptEulaComponent} from './eula/accept-eula/accept-eula.component';
 import {FUsersComponent} from './admin/states/f-users/f-users.component';
 import {FUnitsComponent} from './admin/states/f-units/f-units.component';
+import { CoursemapComponent } from './courseflow/coursemap/coursemap.component';
 
 /*
  * Use this file to store any states that are sourced by angular components.
@@ -291,6 +292,20 @@ const ViewAllUnits: NgHybridStateDeclaration = {
   },
 };
 
+const CoursemapState: NgHybridStateDeclaration = {
+  name: 'coursemap',
+  url: '/coursemap',
+  views: {
+    main: {
+      component: CoursemapComponent,
+    },
+  },
+  data: {
+    pageTitle: 'Coursemap',
+    roleWhitelist: ['Student', 'Tutor', 'Convenor', 'Admin', 'Auditor'],
+  },
+};
+
 /**
  * Export the list of states we have created in angular
  */
@@ -306,4 +321,7 @@ export const doubtfireStates = [
   ViewAllProjectsState,
   ViewAllUnits,
   AdministerUnits,
+  CoursemapState,
 ];
+
+


### PR DESCRIPTION
_Any italic text should be deleted from the final Pull Request text, including this line_

# Description

This feature adds the capability to mark units as "complete" within the study period container. Once a unit is marked as complete, it is no longer draggable or moveable between containers, ensuring that completed units are locked in place and cannot be mistakenly altered. This helps maintain the integrity of the study schedule and prevents unintentional changes to completed tasks.

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

How to test the feature:
 - Fork this pr: https://github.com/doubtfire-lms/doubtfire-api/pull/448
 - Then generate testing unit_definion data by using listed rake command
 - Elective units only fetching while you are using administrator

I have tested the feature in the following environments:
- Marked units as complete and verified they cannot be dragged or dropped in any study period container.
- Verified that units not marked as complete remain draggable as expected.

Screenshot:
![Screenshot 2025-03-29 171446](https://github.com/user-attachments/assets/ff7f2343-43b9-4a84-b0a7-2e8a0d395999)



## Testing Checklist:

- [X] Tested in latest Chrome
- [ ] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
