### PR TITLE
Feature/update courseflow feature

### DIFF
--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -1,17 +1,42 @@
 <div class="coursemap">
-  <!-- Required Units Panel -->
+  <!-- Filter Units Container -->
   <div class="required-units-container">
+    <!-- Required Units Panel -->
     <div class="required-units-header">
       <h3 class="required-units-title">Required Units</h3>
     </div>
+    <div class="filter-container">
+      <div class="filter-header">
+        <h3 class="filter-title">Please Select Your Interest/Area</h3>
+      </div>
+      <label for="level">Level:</label>
+      <select id="level" [(ngModel)]="selectedLevel" (change)="filterUnits()">
+        <option *ngFor="let level of levels" [value]="level">{{ level }}</option>
+      </select>
+
+      <label for="year">Year:</label>
+      <select id="year" [(ngModel)]="selectedYear" (change)="filterUnits()">
+        <option *ngFor="let year of unityears" [value]="year">{{ year }}</option>
+      </select>
+
+      <label for="teachingPeriod">Teaching Period:</label>
+      <select id="teachingPeriod" [(ngModel)]="selectedTeachingPeriod" (change)="filterUnits()">
+        <option *ngFor="let period of teachingPeriods" [value]="period">{{ period }}</option>
+      </select>
+
+      <label for="specialization">Specialization:</label>
+      <select id="specialization" [(ngModel)]="selectedSpecialization" (change)="filterUnits()">
+        <option *ngFor="let spec of specializations" [value]="spec">{{ spec }}</option>
+      </select>
+    </div>
     <div
       cdkDropList
-      [cdkDropListData]="requiredUnits"
+      [cdkDropListData]="filteredUnits"
       (cdkDropListDropped)="drop($event)"
       [cdkDropListConnectedTo]="connectedDropLists"
       [id]="'requiredUnits'"
     >
-      <div class="unit" *ngFor="let unit of requiredUnits" cdkDrag>
+      <div class="unit" *ngFor="let unit of filteredUnits" cdkDrag>
         <strong>{{ unit.code }}</strong> - {{ unit.name }}
       </div>
     </div>

--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -27,7 +27,7 @@
         [id]="electiveUnits"
       >
         <div class="text" *ngFor="let unit of electiveUnits" cdkDrag class="unit">
-          <p >
+          <p>
             <strong>{{ unit.code }}</strong> - {{ unit.name }}
           </p>
         </div>
@@ -36,7 +36,13 @@
         <div>
           <mat-form-field appearance="fill">
             <mat-label>Enter Unit Code</mat-label>
-            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode"/>
+            <input
+              class="search-bar"
+              matInput
+              [(ngModel)]="unitCode"
+              name="unitCode"
+              id="unitCode"
+            />
           </mat-form-field>
           <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
 
@@ -62,7 +68,7 @@
       </div>
       <!-- Trimester 1 -->
       <div
-      *ngIf="year.trimester1"
+        *ngIf="year.trimester1"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester1"
@@ -72,8 +78,18 @@
       >
         <h5 class="trimester-heading">Trimester 1</h5>
 
-        <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester1"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 0)">
           <mat-icon>delete</mat-icon>
@@ -81,7 +97,7 @@
       </div>
       <!-- Trimester 2 -->
       <div
-      *ngIf="year.trimester2"
+        *ngIf="year.trimester2"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester2"
@@ -91,8 +107,18 @@
       >
         <h5 class="trimester-heading">Trimester 2</h5>
 
-        <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester2"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 1)">
           <mat-icon>delete</mat-icon>
@@ -100,7 +126,7 @@
       </div>
       <!-- Trimester 3 -->
       <div
-      *ngIf="year.trimester3"
+        *ngIf="year.trimester3"
         cdkDropList
         class="trimester-list"
         [cdkDropListData]="year.trimester3"
@@ -110,8 +136,18 @@
       >
         <h5 class="trimester-heading">Trimester 3</h5>
 
-        <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester3"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 2)">
           <mat-icon>delete</mat-icon>

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -11,6 +11,60 @@
   max-height: 90vh;
 }
 
+.filter-container {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 30px;
+}
+
+.filter-header {
+  margin-bottom: 16px;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 8px;
+}
+
+.filter-title {
+  margin: 0;
+  font-size: 18px;
+  color: #333;
+  font-weight: 500;
+}
+
+label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #555;
+  margin-bottom: 4px;
+  display: block;
+}
+
+select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 14px;
+  color: #333;
+  appearance: none;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+  }
+
+  &:hover {
+    border-color: #999;
+  }
+
+  option {
+    padding: 8px;
+  }
+}
+
 /* Required Units Panel */
 .required-units-container {
   width: 25%;
@@ -161,5 +215,15 @@
 
   .required-units-container, .study-periods-container {
     width: 100%;
+  }
+
+  .filter-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px 20px;
+
+    .filter-header {
+      grid-column: 1 / -1;
+    }
   }
 }

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,142 +1,165 @@
-.required-units-container {
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  display: flex;
-  height: 80vh;
-  vertical-align: top;
-  align-items: left;
-  flex-direction: column;
-  width: 100%; /* Fill available space on mobile */
-  max-width: 25vw;
-}
-
-.year-container {
-  margin: 16px;
-  border: 1px solid #337ab7;
-  border-radius: 9px;
-  display: flex;
-  vertical-align: top;
-  flex-direction: column;
-  border-radius: 6px;
-  width: 98%;
-  justify-content: center;
-  align-items: center;
-}
-
-.trimester-list {
-  display: flex;
-  flex-direction: row; /* Makes the items within the list display horizontally */
-  padding: 10px;
-  border-radius: 6px;
-  background-color: rgb(238, 238, 238);
-  margin: 10px;
-  align-items: center;
-  width: 95%;
-}
-
-.unit {
-  padding: 8px;
-  margin: 8px 0 8px 5%;
-  background-color: #357bb9a8;
-  color: white;
-  border-radius: 6px;
-  cursor: move;
-  align-content: center;
-  height: 8vh;
-  width: 90%;
-}
-
-.study-periods-container {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  margin-left: 20px;
-  width: 70vw;
-  align-items: center;
-}
-
-.study-periods-header, .required-units-header, .year-header{
-  background-color: #337ab7;
-  border-radius: 5px 5px 0 0;
-  color: white;
-  height: 40px;
-  align-items: center;
-  display: flex;
-  padding: 0 10px;
-  width: 100%;
-  font-size: 1.2rem; /* Adjust to ensure readability on smaller screens */
-}
-
-.study-periods-title, .required-units-title, .year-title, .electives-title {
-  font-size: 2rem; /* Default font size for larger screens */
-  margin: 0 2%;
-}
-
-.form {
-  margin: 0 2%;
-}
-
-.text {
-  margin: auto 2% auto 2%;
-}
-
-.electives-container {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  margin: auto 0 8px 5%;
-}
-
-mat-form-field {
-  width: 75%;
-
-}
-
-.search-bar {
-  margin: 0 1% 0 1%;
-  width: 70%;
-}
-
-.button {
-  border-radius: 5px;
-  margin: 0 2% 2% 2%;
-}
-
 .coursemap {
   display: flex;
   flex-direction: row;
+  gap: 20px;
+  width: 80%;
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+  max-height: 90vh;
+}
+
+/* Required Units Panel */
+.required-units-container {
+  width: 25%;
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.completed {
+  text-decoration: line-through;
+  color: grey;
+}
+
+.required-units-title, .electives-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.unit {
+  background: #e3e7ed;
+  padding: 10px;
+  margin: 5px 0;
+  border-radius: 5px;
+  cursor: grab;
+  transition: background 0.3s;
+}
+
+.unit-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.complete-checkbox {
+  margin-left: auto; /* Ensure the checkbox stays on the far right */
+  cursor: pointer;
+}
+
+.unit:hover {
+  background: #d0d4db;
+}
+
+.search-bar {
+  width: 100%;
+  padding: 8px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+.button {
+  margin-top: 10px;
+  width: 100%;
+  background-color: #007bff;
+  color: white;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: #0056b3;
+}
+
+/* Study Periods Panel */
+.study-periods-container {
+  width: 70%;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.year-container {
+  background: #f9fafc;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.year-title {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.trimester-list {
+  background: #eef1f6;
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .trimester-heading {
-  margin-right: 20px;
-  align-items: center;
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .delete-button {
-  margin-left: auto;
-  right: 2%;
-  display: flex;
-  flex-shrink: 1;
+  background: none;
+  border: none;
+  color: red;
+  cursor: pointer;
 }
 
-@media only screen and (max-width: 775px) {
-  .study-periods-title, .required-units-title, .year-title, .electives-title {
-    font-size: 2.7vw;
-  }
-
-  .text {
-    margin: auto 2% auto 2%;
-    font-size: 1.7vw;
-  }
-
-  .unit {
-    font-size: 1.65vw;
-  }
-
-
+.add-button {
+  display: block;
+  width: 100%;
+  background: #28a745;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  margin-top: 10px;
 }
 
+.add-button:hover {
+  background: #218838;
+}
 
+.completed {
+  text-decoration: line-through;
+  color: grey;
+  opacity: 0.7;
+  cursor: pointer;
+}
 
+.checkmark {
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.inactive {
+  color: lightgray;
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .coursemap {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .required-units-container, .study-periods-container {
+    width: 100%;
+  }
+}

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -27,7 +27,7 @@
   color: grey;
 }
 
-.required-units-title, .electives-title {
+.required-units-title, .electives-title .study-periods-title {
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 10px;

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -101,6 +101,33 @@ export class CoursemapComponent implements OnInit {
 
   completedUnits: Set<string> = new Set(); // Stores completed unit codes
 
+  unitLevels: Map<string, number> = new Map(); // Map to store unit levels
+
+  unitYears: Map<string, number> = new Map(); // Map to store unit years
+
+  unitTeachingPeriods: Map<string, UnitDefinition[]> = new Map(); // Map to store unit teaching periods
+
+  specializationUnits: Map<string, UnitDefinition[]> = new Map(); // Map to store specialization units
+
+  // Demo data for filtering
+  filteredElectiveUnits: Unit[] = [];
+  filteredUnits: UnitDefinition[] = [];
+  levels: string[] = ['All Levels', '1', '2', '3']; // Example levels
+  unityears: string[] = ['All Years', '2025', '2026', '2027', '2028']; // Example years
+  teachingPeriods: string[] = ['All Periods', 'Trimester 1', 'Trimester 2', 'Trimester 3']; // Example teaching periods
+  specializations: string[] = [
+    'All Specializations',
+    'Cyber Security',
+    'Data Analytics',
+    'Software Development',
+    'IT Management',
+  ]; // Specializations
+
+  selectedLevel: string = 'All Levels';
+  selectedYear: string = 'All Years';
+  selectedTeachingPeriod: string = 'All Periods';
+  selectedSpecialization: string = 'All Specializations';
+
   ngOnInit(): void {
     this.formData = {
       username: '',
@@ -149,6 +176,59 @@ export class CoursemapComponent implements OnInit {
       next: (data: Unit[]) => {
         this.units = data;
         this.errorMessage = null;
+        // Initialize the map for trimester units
+        // Assuming teaching periods are between trimester 1 and 3
+        // Remember this is only for demonstating
+        // purposes and should be replaced with actual logic
+        const teachingPeriods = ['Trimester 1', 'Trimester 2', 'Trimester 3'];
+        teachingPeriods.forEach((period) => {
+          this.unitTeachingPeriods.set(period, []); // Create an empty array for each teaching period
+        });
+        // Initialize the map for specialization units
+        // Assuming specializations are predefined
+        // You can replace this with actual data from your database
+        // For demonstration, let's say we have 4 specializations
+        // You can replace this with actual data from your database
+        const specializations = [
+          'Cyber Security',
+          'Data Analytics',
+          'Software Development',
+          'IT Management',
+        ];
+        specializations.forEach((spec) => {
+          this.specializationUnits.set(spec, []); // Create an empty array for each specialization
+        });
+
+        data.forEach((unit) => {
+          // Populate unit levels here (dummy logic based on code e.g., SIT111 => Level 1)
+          const level = this.extractLevelFromCode(unit.code);
+          this.unitLevels.set(unit.code, level);
+          // Populate unit years with random values (for demonstration purposes)
+          const randomYear = this.getRandomYear();
+          this.unitYears.set(unit.code, randomYear);
+          // Populate unit teaching periods with random values (for demonstration purposes)
+          // Assuming teaching periods are between trimester 1 and 3
+          // You can adjust this logic based on your actual requirements
+          const randomTeachingPeriod = this.getRandomTeachingPeriod(teachingPeriods);
+          this.unitTeachingPeriods.get(randomTeachingPeriod)?.push(unit);
+          // Randomly assign each unit to a specialization
+          const randomSpecialization = this.getRandomSpecialization(specializations);
+          this.specializationUnits.get(randomSpecialization)?.push(unit);
+          console.log(
+            `Unit: ${unit.code}, Level: ${level}, Year: ${randomYear}, Teaching Periods: {randomTeachingPeriod}`,
+          ); // Log for debugging
+        });
+
+        // Log the populated specialization units data for debugging
+        console.log('Cyber Security Units:', this.specializationUnits.get('Cyber Security'));
+        console.log('Data Analytics Units:', this.specializationUnits.get('Data Analytics'));
+        console.log(
+          'Software Development Units:',
+          this.specializationUnits.get('Software Development'),
+        );
+        console.log('IT Management Units:', this.specializationUnits.get('IT Management'));
+
+        this.filteredElectiveUnits = data;
       },
       error: (err) => {
         this.errorMessage = 'Error fetching units';
@@ -160,12 +240,67 @@ export class CoursemapComponent implements OnInit {
       next: (data: UnitDefinition[]) => {
         this.requiredUnits = data;
         this.errorMessage = null;
+
+        // Initialize the map for trimester units
+        // Assuming teaching periods are between trimester 1 and 3
+        // Remember this is only for demonstating
+        // purposes and should be replaced with actual logic
+        const teachingPeriods = ['Trimester 1', 'Trimester 2', 'Trimester 3'];
+        teachingPeriods.forEach((period) => {
+          this.unitTeachingPeriods.set(period, []); // Create an empty array for each teaching period
+        });
+        // Initialize the map for specialization units
+        // Assuming specializations are predefined
+        // You can replace this with actual data from your database
+        // For demonstration, let's say we have 4 specializations
+        // You can replace this with actual data from your database
+        const specializations = [
+          'Cyber Security',
+          'Data Analytics',
+          'Software Development',
+          'IT Management',
+        ];
+        specializations.forEach((spec) => {
+          this.specializationUnits.set(spec, []); // Create an empty array for each specialization
+        });
+
+        data.forEach((unit) => {
+          // Populate unit levels here (dummy logic based on code e.g., SIT111 => Level 1)
+          const level = this.extractLevelFromCode(unit.code);
+          this.unitLevels.set(unit.code, level);
+          // Populate unit years with random values (for demonstration purposes)
+          const randomYear = this.getRandomYear();
+          this.unitYears.set(unit.code, randomYear);
+          // Populate unit teaching periods with random values (for demonstration purposes)
+          // Assuming teaching periods are between trimester 1 and 3
+          // You can adjust this logic based on your actual requirements
+          const randomTeachingPeriod = this.getRandomTeachingPeriod(teachingPeriods);
+          this.unitTeachingPeriods.get(randomTeachingPeriod)?.push(unit);
+          // Randomly assign each unit to a specialization
+          const randomSpecialization = this.getRandomSpecialization(specializations);
+          this.specializationUnits.get(randomSpecialization)?.push(unit);
+          console.log(
+            `Unit: ${unit.code}, Level: ${level}, Year: ${randomYear}, Teaching Periods: {randomTeachingPeriod}`,
+          ); // Log for debugging
+        });
+
+        // Log the populated specialization units data for debugging
+        console.log('Cyber Security Units:', this.specializationUnits.get('Cyber Security'));
+        console.log('Data Analytics Units:', this.specializationUnits.get('Data Analytics'));
+        console.log(
+          'Software Development Units:',
+          this.specializationUnits.get('Software Development'),
+        );
+        console.log('IT Management Units:', this.specializationUnits.get('IT Management'));
+
+        // Filter units based on selected criteria
+        this.filteredUnits = data;
       },
       error: (err) => {
         this.errorMessage = 'Error fetching units';
         console.error('Error fetching unit definitions:', err);
       },
-    })
+    });
     //temporarily create coursemap with id of 1 until database is loaded
     this.courseMapService.addCourseMap(1, 1);
     //add empty units to coursemap to initialise study periods
@@ -180,7 +315,39 @@ export class CoursemapComponent implements OnInit {
       }
     );
   }
-
+  // Handle method for filtering units based on selected criteria
+  filterUnits() {
+    this.filteredUnits = this.requiredUnits.filter((unit) => {
+      const levelMatch =
+        this.selectedLevel === 'All Levels' ||
+        this.unitLevels.get(unit.code) === parseInt(this.selectedLevel);
+      const yearMatch =
+        this.selectedYear === 'All Years' ||
+        this.unitYears.get(unit.code) === parseInt(this.selectedYear);
+      const periodMatch =
+        this.selectedTeachingPeriod === 'All Periods' ||
+        (this.unitTeachingPeriods.get(this.selectedTeachingPeriod)?.includes(unit) ?? false);
+      const specializationMatch =
+        this.selectedSpecialization === 'All Specializations' ||
+        (this.specializationUnits.get(this.selectedSpecialization)?.includes(unit) ?? false);
+      return levelMatch && yearMatch && periodMatch && specializationMatch;
+    });
+    this.filteredElectiveUnits = this.units.filter((unit) => {
+      const levelMatch =
+        this.selectedLevel === 'All Levels' ||
+        this.unitLevels.get(unit.code) === parseInt(this.selectedLevel);
+      const yearMatch =
+        this.selectedYear === 'All Years' ||
+        this.unitYears.get(unit.code) === parseInt(this.selectedYear);
+      const periodMatch =
+        this.selectedTeachingPeriod === 'All Periods' ||
+        (this.unitTeachingPeriods.get(this.selectedTeachingPeriod)?.includes(unit) ?? false);
+      const specializationMatch =
+        this.selectedSpecialization === 'All Specializations' ||
+        (this.specializationUnits.get(this.selectedSpecialization)?.includes(unit) ?? false);
+      return levelMatch && yearMatch && periodMatch && specializationMatch;
+    });
+  }
   populateYearsArray(courseMapUnits: CourseMapUnit[]) {
     this.years = [];
 
@@ -313,12 +480,37 @@ export class CoursemapComponent implements OnInit {
     }
   }
 
+  extractLevelFromCode(code: string): number {
+    // Extracts the first digit from the numeric part of the unit code (e.g., SIT111 -> 1)
+    const match = code.match(/\d+/);
+    if (match && match[0]) {
+      return parseInt(match[0].charAt(0), 10);
+    }
+    return 0; // Unknown or invalid format
+  }
+
+  getRandomYear(): number {
+    // Generates a random number between 2025 and 2028
+    return Math.floor(Math.random() * 4) + 2025;
+  }
+
+  // Randomly assigns a specialization to a unit
+  getRandomSpecialization(specializations: string[]): string {
+    const randomIndex = Math.floor(Math.random() * specializations.length);
+    return specializations[randomIndex]; // Randomly returns one of the specializations
+  }
+
+  getRandomTeachingPeriod(periods: string[]): string {
+    const randomIndex = Math.floor(Math.random() * periods.length);
+    return periods[randomIndex]; // Randomly returns one of the teaching periods
+  }
   // Toggle completion state
   toggleCompletion(unit: UnitDefinition) {
     this.completedUnits.has(unit.code)
       ? this.completedUnits.delete(unit.code)
       : this.completedUnits.add(unit.code);
-      console.log('Completed units:', this.completedUnits);
+
+    console.log('Completed units:', this.completedUnits);
   }
 
   // Check if a unit is completed

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -333,14 +333,14 @@ export class CoursemapComponent implements OnInit {
       return;
     }
 
-    const alreadyAdded = this.electiveUnits.some(unit => unit.code === this.unitCode);
+    const alreadyAdded = this.electiveUnits.some((unit) => unit.code === this.unitCode);
 
     if (alreadyAdded) {
       this.errorMessage = 'Unit already added';
       return;
     }
 
-    const foundUnit = this.units.find(unit => unit.code === this.unitCode);
+    const foundUnit = this.units.find((unit) => unit.code === this.unitCode);
 
     if (foundUnit) {
       this.electiveUnits.push(foundUnit);

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -92,13 +92,14 @@ export class CoursemapComponent implements OnInit {
   // Temporarily creating a course until database is populated with real data
   testCourse: Course = {
     id: '12345',
-    name: 'Introduction to Programming',
-    code: 'CS101',
+    name: 'Bachelor of Cyber Security',
+    code: 'S334',
     year: 2024,
     version: 'v1.0',
-    url: 'http://university.edu/courses/cs101',
+    url: 'http://example.com',
   };
 
+  completedUnits: Set<string> = new Set(); // Stores completed unit codes
 
   ngOnInit(): void {
     this.formData = {
@@ -123,7 +124,7 @@ export class CoursemapComponent implements OnInit {
     this.courseService.getCourses().subscribe({
       next: (data: Course[]) => {
         this.courses = data;
-        console.log('Courses:', this.courses); // Optional: Log the courses to verify
+        console.log('Courses:', this.testCourse); // Optional: Log the courses to verify
       },
       error: (err) => {
         this.errorMessage = 'Error fetching courses';
@@ -166,7 +167,7 @@ export class CoursemapComponent implements OnInit {
       },
     })
     //temporarily create coursemap with id of 1 until database is loaded
-    this.courseMapService.addCourseMap(1,1);
+    this.courseMapService.addCourseMap(1, 1);
     //add empty units to coursemap to initialise study periods
     this.courseMapUnitService.getCourseMapUnitsById(1).subscribe(
       (data: CourseMapUnit[]) => {
@@ -183,7 +184,7 @@ export class CoursemapComponent implements OnInit {
   populateYearsArray(courseMapUnits: CourseMapUnit[]) {
     this.years = [];
 
-    courseMapUnits.forEach(unit => {
+    courseMapUnits.forEach((unit) => {
       console.log('Processing unit with yearSlot:', unit.yearSlot); // Log the yearSlot value
 
       // Find the year object with the same yearSlot value
@@ -309,10 +310,21 @@ export class CoursemapComponent implements OnInit {
         event.previousIndex,
         event.currentIndex,
       );
-
-
     }
+  }
 
+  // Toggle completion state
+  toggleCompletion(unit: UnitDefinition) {
+    if (this.completedUnits.has(unit.code)) {
+      this.completedUnits.delete(unit.code);
+    } else {
+      this.completedUnits.add(unit.code);
+    }
+  }
+
+  // Check if a unit is completed
+  isCompleted(unit: UnitDefinition): boolean {
+    return this.completedUnits.has(unit.code);
   }
 
   fetchUnitByCode(): void {
@@ -339,5 +351,4 @@ export class CoursemapComponent implements OnInit {
       this.unit = null;
     }
   }
-
 }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -315,11 +315,11 @@ export class CoursemapComponent implements OnInit {
 
   // Toggle completion state
   toggleCompletion(unit: UnitDefinition) {
-    if (this.completedUnits.has(unit.code)) {
-      this.completedUnits.delete(unit.code);
-    } else {
-      this.completedUnits.add(unit.code);
-    }
+    this.completedUnits.has(unit.code)
+      ? this.completedUnits.delete(unit.code)
+      : this.completedUnits.add(unit.code);
+
+    console.log('Completed units:', this.completedUnits);
   }
 
   // Check if a unit is completed

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -110,7 +110,6 @@ export class CoursemapComponent implements OnInit {
   specializationUnits: Map<string, UnitDefinition[]> = new Map(); // Map to store specialization units
 
   // Demo data for filtering
-  filteredElectiveUnits: Unit[] = [];
   filteredUnits: UnitDefinition[] = [];
   levels: string[] = ['All Levels', '1', '2', '3']; // Example levels
   unityears: string[] = ['All Years', '2025', '2026', '2027', '2028']; // Example years
@@ -176,59 +175,6 @@ export class CoursemapComponent implements OnInit {
       next: (data: Unit[]) => {
         this.units = data;
         this.errorMessage = null;
-        // Initialize the map for trimester units
-        // Assuming teaching periods are between trimester 1 and 3
-        // Remember this is only for demonstating
-        // purposes and should be replaced with actual logic
-        const teachingPeriods = ['Trimester 1', 'Trimester 2', 'Trimester 3'];
-        teachingPeriods.forEach((period) => {
-          this.unitTeachingPeriods.set(period, []); // Create an empty array for each teaching period
-        });
-        // Initialize the map for specialization units
-        // Assuming specializations are predefined
-        // You can replace this with actual data from your database
-        // For demonstration, let's say we have 4 specializations
-        // You can replace this with actual data from your database
-        const specializations = [
-          'Cyber Security',
-          'Data Analytics',
-          'Software Development',
-          'IT Management',
-        ];
-        specializations.forEach((spec) => {
-          this.specializationUnits.set(spec, []); // Create an empty array for each specialization
-        });
-
-        data.forEach((unit) => {
-          // Populate unit levels here (dummy logic based on code e.g., SIT111 => Level 1)
-          const level = this.extractLevelFromCode(unit.code);
-          this.unitLevels.set(unit.code, level);
-          // Populate unit years with random values (for demonstration purposes)
-          const randomYear = this.getRandomYear();
-          this.unitYears.set(unit.code, randomYear);
-          // Populate unit teaching periods with random values (for demonstration purposes)
-          // Assuming teaching periods are between trimester 1 and 3
-          // You can adjust this logic based on your actual requirements
-          const randomTeachingPeriod = this.getRandomTeachingPeriod(teachingPeriods);
-          this.unitTeachingPeriods.get(randomTeachingPeriod)?.push(unit);
-          // Randomly assign each unit to a specialization
-          const randomSpecialization = this.getRandomSpecialization(specializations);
-          this.specializationUnits.get(randomSpecialization)?.push(unit);
-          console.log(
-            `Unit: ${unit.code}, Level: ${level}, Year: ${randomYear}, Teaching Periods: {randomTeachingPeriod}`,
-          ); // Log for debugging
-        });
-
-        // Log the populated specialization units data for debugging
-        console.log('Cyber Security Units:', this.specializationUnits.get('Cyber Security'));
-        console.log('Data Analytics Units:', this.specializationUnits.get('Data Analytics'));
-        console.log(
-          'Software Development Units:',
-          this.specializationUnits.get('Software Development'),
-        );
-        console.log('IT Management Units:', this.specializationUnits.get('IT Management'));
-
-        this.filteredElectiveUnits = data;
       },
       error: (err) => {
         this.errorMessage = 'Error fetching units';
@@ -318,21 +264,6 @@ export class CoursemapComponent implements OnInit {
   // Handle method for filtering units based on selected criteria
   filterUnits() {
     this.filteredUnits = this.requiredUnits.filter((unit) => {
-      const levelMatch =
-        this.selectedLevel === 'All Levels' ||
-        this.unitLevels.get(unit.code) === parseInt(this.selectedLevel);
-      const yearMatch =
-        this.selectedYear === 'All Years' ||
-        this.unitYears.get(unit.code) === parseInt(this.selectedYear);
-      const periodMatch =
-        this.selectedTeachingPeriod === 'All Periods' ||
-        (this.unitTeachingPeriods.get(this.selectedTeachingPeriod)?.includes(unit) ?? false);
-      const specializationMatch =
-        this.selectedSpecialization === 'All Specializations' ||
-        (this.specializationUnits.get(this.selectedSpecialization)?.includes(unit) ?? false);
-      return levelMatch && yearMatch && periodMatch && specializationMatch;
-    });
-    this.filteredElectiveUnits = this.units.filter((unit) => {
       const levelMatch =
         this.selectedLevel === 'All Levels' ||
         this.unitLevels.get(unit.code) === parseInt(this.selectedLevel);

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -318,8 +318,7 @@ export class CoursemapComponent implements OnInit {
     this.completedUnits.has(unit.code)
       ? this.completedUnits.delete(unit.code)
       : this.completedUnits.add(unit.code);
-
-    console.log('Completed units:', this.completedUnits);
+      console.log('Completed units:', this.completedUnits);
   }
 
   // Check if a unit is completed


### PR DESCRIPTION
# Description

This feature adds the capability to mark units as "complete" within the study period container. Once a unit is marked as complete, it is no longer draggable or moveable between containers, ensuring that completed units are locked in place and cannot be mistakenly altered. This helps maintain the integrity of the study schedule and prevents unintentional changes to completed tasks.
Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

How to test the feature:
- Fork this pr: https://github.com/doubtfire-lms/doubtfire-api/pull/448
- Then generate testing unit_definion data by using listed rake command
- Elective units only fetching while you are using administrator

I have tested the feature in the following environments:
- Marked units as complete and verified they cannot be dragged or dropped in any study period container.
- Verified that units not marked as complete remain draggable as expected.

Screenshot:
![Screenshot 2025-03-29 171446](https://github.com/user-attachments/assets/f4df9e5c-2d2c-49ac-a7c5-6a18b925e635)

## Testing Checklist:

- [X] Tested in latest Chrome
- [ ] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
