### PR TITLE
feat: add ZIP file upload support in the frontend

### DIFF
--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-upload/task-definition-upload.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-upload/task-definition-upload.component.html
@@ -17,7 +17,7 @@
         <mat-option value="code">Code</mat-option>
         <mat-option value="document">Document</mat-option>
         <mat-option value="image">Image</mat-option>
-        <mat-option value="zip">ZIP file</mat-option>
+        <mat-option value="zip">ZIP</mat-option>
       </mat-select>
     </td>
   </ng-container>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-upload/task-definition-upload.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-upload/task-definition-upload.component.html
@@ -17,6 +17,7 @@
         <mat-option value="code">Code</mat-option>
         <mat-option value="document">Document</mat-option>
         <mat-option value="image">Image</mat-option>
+        <mat-option value="zip">ZIP file</mat-option>
       </mat-select>
     </td>
   </ng-container>


### PR DESCRIPTION
# Description

This added a new ZIP file option for file uploads, when students upload their tasks. Admins now can select upload file type as ZIP. This PR is just for the Front-end Logic.



## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

This has been testing in the front end, making sure that the new option comes up in the front end.

![image](https://github.com/user-attachments/assets/b3de9e31-0130-494d-aa90-aba15bb907a7)


## Testing Checklist:

- [x] Tested in latest Chrome
- [] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
