### PR TITLE
Feature/import download tutorials csv frontend

### DIFF
--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -34,6 +34,9 @@
 
     <span class="grow"></span>
 
+    @if (currentUser.role === 'Admin') {
+      <f-tutorial-csv></f-tutorial-csv>
+    }
     @if (currentUser.role === 'Admin' || currentUser.role === 'Convenor') {
       <button
         #menuState="matMenuTrigger"

--- a/src/app/common/header/tutorial-csv/tutorial-csv.component.html
+++ b/src/app/common/header/tutorial-csv/tutorial-csv.component.html
@@ -1,0 +1,23 @@
+<div class="flex items-center">
+  <button mat-button [matMenuTriggerFor]="tutorialMenu" #tutorialMenuTrigger="matMenuTrigger">
+    <span class="flex items-center">
+      <span>Tutorials</span>
+      <mat-icon>{{ tutorialMenuTrigger.menuOpen ? 'arrow_drop_up' : 'arrow_drop_down' }}</mat-icon>
+    </span>
+  </button>
+
+  <mat-menu #tutorialMenu="matMenu" class="tutorial-dropdown-menu">
+    <button mat-menu-item (click)="fileInput.click()">
+      <mat-icon>upload_file</mat-icon>
+      <span>Upload Tutorial</span>
+    </button>
+
+    <button mat-menu-item (click)="downloadFile()">
+      <mat-icon>download</mat-icon>
+      <span>Download Tutorials</span>
+    </button>
+  </mat-menu>
+
+  <!-- Hidden file input -->
+  <input type="file" accept=".csv" #fileInput (change)="onFileChange($event)" hidden />
+</div>

--- a/src/app/common/header/tutorial-csv/tutorial-csv.component.scss
+++ b/src/app/common/header/tutorial-csv/tutorial-csv.component.scss
@@ -1,0 +1,3 @@
+.small-font {
+  font-size: 12px;  
+}

--- a/src/app/common/header/tutorial-csv/tutorial-csv.component.spec.ts
+++ b/src/app/common/header/tutorial-csv/tutorial-csv.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TutorialCsvComponent } from './tutorial-csv.component';
+
+describe('TutorialCsvComponent', () => {
+  let component: TutorialCsvComponent;
+  let fixture: ComponentFixture<TutorialCsvComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TutorialCsvComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TutorialCsvComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/header/tutorial-csv/tutorial-csv.component.ts
+++ b/src/app/common/header/tutorial-csv/tutorial-csv.component.ts
@@ -1,0 +1,210 @@
+import {Component, OnInit, ViewChild, ElementRef} from '@angular/core';
+import {MediaObserver} from 'ng-flex-layout';
+
+@Component({
+  selector: 'f-tutorial-csv',
+  templateUrl: './tutorial-csv.component.html',
+  styleUrl: './tutorial-csv.component.scss',
+})
+export class TutorialCsvComponent implements OnInit {
+  @ViewChild('fileInput') fileInput: ElementRef | undefined; // Reference to file input
+  file: File | null = null; // Store the selected file
+  responseMessage: string = '';
+  successMessages: unknown[] = [];
+  ignoredMessages: unknown[] = [];
+  errorMessages: unknown[] = [];
+
+  constructor(public media: MediaObserver) {}
+
+  ngOnInit(): void {
+    console.log('Component initialized');
+  }
+
+  // Handle file selection
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onFileChange(event: any): void {
+    const selectedFile = event.target.files[0];
+    if (selectedFile) {
+      this.file = selectedFile;
+      this.confirmUpload();
+    }
+  }
+
+  // Show confirmation dialog before uploading the file
+  confirmUpload(): void {
+    if (this.file) {
+      const confirmUpload = window.confirm(
+        `Are you sure you want to upload the file: ${this.file.name}?`,
+      );
+      if (confirmUpload) {
+        this.uploadFile();
+      } else {
+        this.responseMessage = 'File upload cancelled.';
+        this.clearFileInput();
+      }
+    }
+  }
+
+  // Reset file input to trigger the file selection process again
+  clearFileInput(): void {
+    this.file = null;
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    if (fileInput) {
+      fileInput.value = '';
+    }
+  }
+
+  // Upload the selected file
+  uploadFile(): void {
+    if (this.file) {
+      const formData = new FormData();
+      formData.append('file', this.file);
+
+      // Retrieve the token from localStorage
+      const user = JSON.parse(localStorage.getItem('doubtfire_user') || '[]');
+      console.log(user);
+      const token = user.authenticationToken;
+      const username = user.username;
+
+      if (!token) {
+        console.log('No authentication token found!');
+        return;
+      }
+
+      // Make the POST request to upload the CSV file
+      fetch('/api/csv/tutorials/upload', {
+        method: 'POST',
+        headers: {
+          'auth-token': `${token}`,
+          'username': `${username}`,
+        },
+        body: formData,
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to upload CSV');
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (data && Array.isArray(data.success)) {
+            // Extract message fields from the returned objects
+            this.successMessages = data.success.map((item: {message: string}) => item.message);
+            this.ignoredMessages = (data.ignored || []).map(
+              (item: {message: string}) => item.message,
+            );
+            this.errorMessages = (data.errors || []).map((item: {message: string}) => item.message);
+
+            // Set a general response message based on upload result
+            if (this.errorMessages.length > 0) {
+              this.responseMessage = 'There were some errors during the upload.';
+            } else if (this.successMessages.length > 0) {
+              this.responseMessage = 'File uploaded successfully!';
+            } else {
+              this.responseMessage = 'Upload completed, but no new tutorials were processed.';
+            }
+
+            // Clear the file input after the upload
+            this.file = null;
+            this.fileInput.nativeElement.value = ''; // Reset the file input
+
+            // Optionally show the messages to the user
+            this.showMessages();
+          } else {
+            // Handle unexpected response format
+            this.responseMessage = 'Invalid response format from the server.';
+            console.error('Invalid response:', data);
+          }
+        })
+        .catch((error) => {
+          this.responseMessage = `Error: ${error.message}`;
+          console.error('Error:', error);
+        });
+    }
+  }
+
+  showMessages(): void {
+    if (this.successMessages.length > 0) {
+      alert(`Success: \n${this.successMessages.join('\n')}`);
+    }
+    if (this.ignoredMessages.length > 0) {
+      alert(`Ignored: \n${this.ignoredMessages.join('\n')}`);
+    }
+    if (this.errorMessages.length > 0) {
+      alert(`Errors: \n${this.errorMessages.join('\n')}`);
+    }
+  }
+
+  downloadFile(): void {
+    const user = JSON.parse(localStorage.getItem('doubtfire_user') || '{}');
+    const token = user.authenticationToken;
+    const username = user.username;
+
+    if (!token) {
+      console.log('No authentication token found!');
+      return;
+    }
+
+    fetch('/api/csv/tutorials/download', {
+      method: 'GET',
+      headers: {
+        'auth-token': `${token}`,
+        'username': `${username}`,
+      },
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error('Failed to download file');
+        return response.blob();
+      })
+      .then((blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'tutorials.csv';
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+        this.responseMessage = 'File downloaded successfully!';
+      })
+      .catch((error) => {
+        this.responseMessage = `Download error: ${error.message}`;
+        console.error(error);
+      });
+  }
+
+  onButtonClick(): void {
+    const user = JSON.parse(localStorage.getItem('doubtfire_user') || '[]');
+    console.log(user);
+    const token = user.authenticationToken;
+    const username = user.username;
+
+    if (!token) {
+      console.log('No authentication token found!');
+      return;
+    } else {
+      console.log('Token found');
+    }
+
+    fetch('/api/ping', {
+      method: 'GET',
+      headers: {
+        'auth-token': `${token}`,
+        'username': `${username}`,
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        console.log('API response:', data);
+        alert('Connection successful: ' + data.message);
+      })
+      .catch((error) => {
+        console.error('Error connecting to API:', error);
+        alert('Failed to connect to API: ' + error.message);
+      });
+  }
+}

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -241,6 +241,7 @@ import {ScormExtensionCommentComponent} from './tasks/task-comments-viewer/scorm
 import {ScormExtensionModalComponent} from './common/modals/scorm-extension-modal/scorm-extension-modal.component';
 import { D2lTransferComponent, D2lTransferModal } from './units/states/portfolios/d2l-transfer-modal/d2l-transfer.component';
 import { SuccessCloseComponent } from './common/success-close/success-close.component';
+import {TutorialCsvComponent} from './common/header/tutorial-csv/tutorial-csv.component';
 
 // See https://stackoverflow.com/questions/55721254/how-to-change-mat-datepicker-date-format-to-dd-mm-yyyy-in-simplest-way/58189036#58189036
 const MY_DATE_FORMAT = {
@@ -325,6 +326,7 @@ const MY_DATE_FORMAT = {
     TaskSubmissionHistoryComponent,
     HeaderComponent,
     UnitDropdownComponent,
+    TutorialCsvComponent,
     TaskDropdownComponent,
     SplashScreenComponent,
     ObjectSelectComponent,


### PR DESCRIPTION
# Description

This PR integrates the TutorialCSVComponent into the main application module and header navigation. Admin users can now import and download tutorial data in CSV format directly from the UI.

<img src="https://github.com/user-attachments/assets/f87e4b48-e1c1-461c-b98c-ae2daff2c1d5" width="600" />

<img src="https://github.com/user-attachments/assets/5bd2a31e-e0c4-4cf1-8e2c-6bab7c2cba8d" width="300" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This change can be tested by pulling the code and logging in as an admin. The tutorial dropdown should appear as shown in the images.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
