### PR TITLE
app-attack-fixes/clickjacking-vulnerability

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -10,8 +10,8 @@ http {
         root /usr/share/nginx/html/;
         index index.html;
         listen 80;
-
-        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data: ws:" always;
+        # Commenting out Content-Security-Policy_headers here so that it won't create over-ride conflict with the security headers mentioned in proxy-nginx.conf
+        # add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data: ws:" always;
         # add_header Feature-Policy "microphone=(self),speaker=(self),fullscreen=(self),payment=(none);" always;
         add_header Permissions-Policy "microphone=(self),speaker=(self),fullscreen=(self),payment=(none)" always;
     }


### PR DESCRIPTION
_Base Branch: app-attack-fixes_

_Note: Making a PR to thoth-tech/doubtfire-web so that this can be merged asap, and HardHat leads can retest this fix._

# Description

_This PR ensures that the internal `nginx.conf` inside `doubtfire-web` does not override the security headers (e.g., `X-Frame-Options`, `Content-Security-Policy`) that are now being enforced via the outer `proxy-nginx.conf` file in the `doubtfire-deploy` repository._

### Note

_Kindly go through the attached [documentation ](https://github.com/thoth-tech/documentation/pull/593) first inorder to understand what this fix is about in detail and how it can be tested._

## What was changed:
- **Commented out** redundant security headers from `doubtfire-web/nginx.conf` to prevent conflict or override with headers applied at the reverse proxy layer (`proxy-nginx.conf`).
- This avoids duplication and ensures centralized management of security headers at the proxy level for consistency across services.

Fixes # (_Header override issues caused by multiple NGINX layers_)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Validated that headers set in `proxy-nginx.conf` (doubtfire-deploy) reflect in browser response
- Confirmed no duplication or override from `doubtfire-web/nginx.conf`
- Ensured static files are still served correctly via inner NGINX
- Yet to test Clickjacking Prevention in a Malicious <Iframe> Setup as listed in the report.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Needs to be tested inside a dedicated environment like kali linux inside a virtual box.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
