### PR TITLE
fix(pdf-viewer): disable JavaScript execution for security

### DIFF
--- a/src/app/common/file-viewer/file-viewer.component.html
+++ b/src/app/common/file-viewer/file-viewer.component.html
@@ -10,6 +10,7 @@
     style="display: block; min-height: 60rem"
     [src]="blobUrl"
     [render-text]="true"
+    [disableJavascript]="true"
     (after-load-complete)="onLoaded()"
     (page-rendered)="loaded = true"
     (on-progress)="onProgress($event)"


### PR DESCRIPTION
This pull request introduces a fix that mitigates malicious code injection in PDF files by disabling JavaScript execution during PDF viewing.

# Description

This change prevents the execution of embedded JavaScript in PDF files, thereby reducing the risk of malicious code being triggered when viewing a PDF.
It addresses a security vulnerability where PDFs could be used as an attack vector.

Fixes: [Insert issue number here]

## Type of Change  
(Select the relevant option(s) and delete the others)

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that may break existing functionality)
- [ ] 📚 Documentation update

# How Has This Been Tested?

The change was tested by loading multiple PDF files (with and without embedded JavaScript) to confirm that no JavaScript is executed during rendering.
Browser console logs and alert behaviors were used to verify JS suppression.

## Test Configuration:

- [x] Latest Chrome
- [x] Latest Safari
- [x] Latest Firefox

# Developer Checklist

- [x] Code adheres to project style guidelines
- [x] Performed self-review and cleaned up the code
- [x] Added comments in complex sections
- [x] Updated relevant documentation
- [x] No new warnings introduced
- [x] I have requested a review from @returnMarcco and @theiris6