### PR TITLE
Add in-system notifications for students

### DIFF
--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -34,6 +34,10 @@
 
     <span class="grow"></span>
 
+    @if (currentUser.role === 'Student') {
+      <f-notifications-button></f-notifications-button>
+    }
+
     @if (currentUser.role === 'Admin' || currentUser.role === 'Convenor') {
       <button
         #menuState="matMenuTrigger"

--- a/src/app/common/header/notifications-button/notifications-button.component.css
+++ b/src/app/common/header/notifications-button/notifications-button.component.css
@@ -1,0 +1,78 @@
+.notification-panel {
+  position: absolute;
+  top: 60px;
+  right: 20px;
+  width: 400px;
+  max-height: 70vh;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  overflow-y: auto;
+  padding: 20px 16px 16px;
+  scrollbar-width: thin;
+  scrollbar-color: #ccc transparent;
+}
+
+.notification-panel::-webkit-scrollbar {
+  width: 6px;
+}
+
+.notification-panel::-webkit-scrollbar-thumb {
+  background-color: #ccc;
+  border-radius: 10px;
+}
+
+.notification-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+}
+
+.notification-content span {
+  flex: 1;
+  margin-right: 8px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.delete-all-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.notification-button {
+  position: relative;
+}
+
+.notification-panel mat-list-item {
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: red;
+  color: white;
+  font-size: 10px;
+  font-weight: bold;
+  border-radius: 50%;
+  padding: 2px 6px;
+  line-height: 1;
+  min-width: 16px;
+  text-align: center;
+}
+
+
+
+
+
+

--- a/src/app/common/header/notifications-button/notifications-button.component.html
+++ b/src/app/common/header/notifications-button/notifications-button.component.html
@@ -1,0 +1,35 @@
+<button mat-icon-button (click)="toggleNotifications()" aria-label="Notifications" class="notification-button">
+  <mat-icon>notifications</mat-icon>
+  <span *ngIf="notifications.length > 0" class="notification-badge">{{ notifications.length }}</span>
+</button>
+
+<!-- Notification List Panel -->
+<div *ngIf="showNotifications" class="notification-panel" #panel>
+  <mat-list>
+    <mat-list-item *ngFor="let note of notifications">
+      <div class="notification-content">
+        <span class="mat-body-2">{{ note.message }}</span>
+        <button mat-icon-button aria-label="Dismiss notification" (click)="dismissNotification(note.id)">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    </mat-list-item>
+
+    <!-- If no notifications -->
+    <mat-list-item *ngIf="notifications.length === 0">
+      <span class="mat-body-2">No notifications</span>
+    </mat-list-item>
+  </mat-list>
+
+  <div *ngIf="notifications.length > 0" class="delete-all-container">
+    <button mat-button color="warn" (click)="deleteAllNotifications()">Delete All</button>
+  </div>
+
+  <div class="close-container">
+    <button mat-button (click)="toggleNotifications()">Close</button>
+  </div>
+</div>
+
+
+
+

--- a/src/app/common/header/notifications-button/notifications-button.component.spec.ts
+++ b/src/app/common/header/notifications-button/notifications-button.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationsButtonComponent } from './notifications-button.component';
+
+describe('NotificationsButtonComponent', () => {
+  let component: NotificationsButtonComponent;
+  let fixture: ComponentFixture<NotificationsButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotificationsButtonComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(NotificationsButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/header/notifications-button/notifications-button.component.ts
+++ b/src/app/common/header/notifications-button/notifications-button.component.ts
@@ -1,0 +1,69 @@
+// import { Component, ElementRef, HostListener, ViewChild } from '@angular/core';
+import { Component, OnInit  } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { AppInjector } from 'src/app/app-injector';
+import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+
+// Define structure of a Notification object
+interface Notification {
+  id: number;
+  message: string;
+}
+
+@Component({
+  selector: 'f-notifications-button',
+  templateUrl: './notifications-button.component.html',
+  styleUrls: ['./notifications-button.component.css']
+})
+export class NotificationsButtonComponent implements OnInit {
+
+  // Tracks whether the notifications dropdown is visible
+  showNotifications = false;
+
+  // List of notifications to be displayed
+  notifications: Notification[] = [];
+
+  private readonly API_URL = AppInjector.get(DoubtfireConstants).API_URL;
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.loadNotifications();
+  }
+
+   // Toggle the visibility of the notifications dropdown
+  toggleNotifications() {
+    this.showNotifications = !this.showNotifications;
+    console.log('showNotifications toggled:', this.showNotifications);
+  }
+
+   // Fetch notifications from the API
+  loadNotifications() {
+    this.http.get<Notification[]>(`${this.API_URL}/notifications`).subscribe({
+      next: data => this.notifications = data,
+      error: err => console.error('Error loading notifications', err)
+    });
+  }
+
+  // Remove a specific notification by ID
+  dismissNotification(notificationId: number) {
+    console.log('Dismissed notification with ID:', notificationId);
+    this.http.delete(`${this.API_URL}/notifications/${notificationId}`).subscribe({
+      next: () => {
+        this.notifications = this.notifications.filter(note => note.id !== notificationId);
+      },
+      error: err => console.error('Error deleting notification', err)
+    });
+  }
+
+  // Delete all notifications
+  deleteAllNotifications() {
+    console.log('All notifications deleted');
+    this.http.delete(`${this.API_URL}/notifications`).subscribe({
+      next: () => {
+        this.notifications = [];
+      },
+      error: err => console.error('Error deleting all notifications', err)
+    });
+  }
+
+}

--- a/src/app/common/header/notifications-button/notifications-button.component.ts
+++ b/src/app/common/header/notifications-button/notifications-button.component.ts
@@ -1,8 +1,8 @@
-// import { Component, ElementRef, HostListener, ViewChild } from '@angular/core';
-import { Component, OnInit  } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, HostListener, ViewChild } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { AppInjector } from 'src/app/app-injector';
 import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+import { Subscription } from 'rxjs';
 
 // Define structure of a Notification object
 interface Notification {
@@ -15,7 +15,7 @@ interface Notification {
   templateUrl: './notifications-button.component.html',
   styleUrls: ['./notifications-button.component.css']
 })
-export class NotificationsButtonComponent implements OnInit {
+export class NotificationsButtonComponent implements OnInit, OnDestroy {
 
   // Tracks whether the notifications dropdown is visible
   showNotifications = false;
@@ -23,47 +23,71 @@ export class NotificationsButtonComponent implements OnInit {
   // List of notifications to be displayed
   notifications: Notification[] = [];
 
+  // Track active subscriptions for cleanup
+  private subscriptions = new Subscription();
+
+  // Reference to the notification panel in the DOM
+  @ViewChild('panel') panelRef!: ElementRef;
+
   private readonly API_URL = AppInjector.get(DoubtfireConstants).API_URL;
+
   constructor(private http: HttpClient) {}
 
   ngOnInit() {
     this.loadNotifications();
   }
 
-   // Toggle the visibility of the notifications dropdown
-  toggleNotifications() {
-    this.showNotifications = !this.showNotifications;
-    console.log('showNotifications toggled:', this.showNotifications);
+  ngOnDestroy() {
+    // Prevent memory leaks
+    this.subscriptions.unsubscribe();
   }
 
-   // Fetch notifications from the API
+  // Close panel when clicking outside of it
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent) {
+    if (this.showNotifications && this.panelRef && !this.panelRef.nativeElement.contains(event.target)) {
+      this.showNotifications = false;
+    }
+  }
+
+  // Toggle the visibility of the notifications dropdown
+  toggleNotifications() {
+    this.showNotifications = !this.showNotifications;
+  }
+
+  // Fetch notifications from the API
   loadNotifications() {
-    this.http.get<Notification[]>(`${this.API_URL}/notifications`).subscribe({
-      next: data => this.notifications = data,
-      error: err => console.error('Error loading notifications', err)
-    });
+    this.subscriptions.add(
+      this.http.get<Notification[]>(`${this.API_URL}/notifications`).subscribe({
+        next: data => this.notifications = data,
+        error: err => console.error('Error loading notifications', err)
+      })
+    );
   }
 
   // Remove a specific notification by ID
   dismissNotification(notificationId: number) {
-    console.log('Dismissed notification with ID:', notificationId);
-    this.http.delete(`${this.API_URL}/notifications/${notificationId}`).subscribe({
-      next: () => {
-        this.notifications = this.notifications.filter(note => note.id !== notificationId);
-      },
-      error: err => console.error('Error deleting notification', err)
-    });
+    this.subscriptions.add(
+      this.http.delete(`${this.API_URL}/notifications/${notificationId}`).subscribe({
+        next: () => {
+          this.notifications = this.notifications.filter(note => note.id !== notificationId);
+        },
+        error: err => console.error('Error deleting notification', err)
+      })
+    );
   }
 
   // Delete all notifications
   deleteAllNotifications() {
-    console.log('All notifications deleted');
-    this.http.delete(`${this.API_URL}/notifications`).subscribe({
-      next: () => {
-        this.notifications = [];
-      },
-      error: err => console.error('Error deleting all notifications', err)
-    });
+    this.subscriptions.add(
+      this.http.delete(`${this.API_URL}/notifications`).subscribe({
+        next: () => {
+          this.notifications = [];
+        },
+        error: err => console.error('Error deleting all notifications', err)
+      })
+    );
   }
 
 }
+

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -253,6 +253,7 @@ import {ScormExtensionModalComponent} from './common/modals/scorm-extension-moda
 import { GradeIconComponent } from './common/grade-icon/grade-icon.component';
 import { GradeTaskModalComponent } from './tasks/modals/grade-task-modal/grade-task-modal.component';
 import { PrivacyPolicy } from './config/privacy-policy/privacy-policy';
+import {NotificationsButtonComponent} from './common/header/notifications-button/notifications-button.component';
 
 // See https://stackoverflow.com/questions/55721254/how-to-change-mat-datepicker-date-format-to-dd-mm-yyyy-in-simplest-way/58189036#58189036
 const MY_DATE_FORMAT = {
@@ -389,6 +390,7 @@ import { UnitStudentEnrolmentModalComponent } from './units/modals/unit-student-
     TaskScormCardComponent,
     ScormExtensionCommentComponent,
     ScormExtensionModalComponent,
+    NotificationsButtonComponent,
   ],
   // Services we provide
   providers: [


### PR DESCRIPTION
# Description

Added a notification panel to display in-system notifications for students. This was created as part of the Staff Grant Extension feature as the design document indicated the need for displaying extension notifications to the student on the homepage. 

As seen below, the bell icon is where students can access their notifications: 

![Screenshot 2025-05-18 at 5 02 32 PM](https://github.com/user-attachments/assets/ad83fbe6-0557-487f-b81a-ca0febe5179e)

When they receive a notification, a red number will appear indicating how many notifcations they currently have: 

![Screenshot 2025-05-18 at 1 51 59 PM](https://github.com/user-attachments/assets/f725512d-271f-4882-97eb-06242b1e50ca)

When the student clicks on this notification, the following panel will appear: 

![Screenshot 2025-05-18 at 3 20 02 PM](https://github.com/user-attachments/assets/90beecc7-b7fd-48f5-a8b1-d79a9544d82e)

They can click on the black "X" to delete a notification (this deletes it from the database) or they can choose to delete all, which deletes all the notifications for that student from the database. 

Additionally, this PR depends on  [PR:69](https://github.com/thoth-tech/doubtfire-api/pull/69). The backend PR contains the table migration, model creation etc to make this feature work. 

## Type of change

_Please delete options that are not relevant._

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

To test this feature, you will need to login as the student (username: astudent, password:password) and ensure that the component is visible. You will most likely see the following message "No notifications" as your database will be empty. 

You can, however, pull the backend code from [PR:69](https://github.com/thoth-tech/doubtfire-api/pull/69) and test that the front end is populated when you create a notification in the backend for the user. Follow the instructions in the backend PR to create a notification if you wish to test the integration. 

![Screenshot 2025-05-18 at 4 27 02 PM](https://github.com/user-attachments/assets/8dee7bd2-d02a-4d7f-84c4-f3f15c46c326)

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
