### PR TITLE
Feature/add capability to mark units as complete in Courseflow

### DIFF
--- a/src/app/courseflow/coursemap/coursemap.component.html
+++ b/src/app/courseflow/coursemap/coursemap.component.html
@@ -27,7 +27,7 @@
         [id]="electiveUnits"
       >
         <div class="text" *ngFor="let unit of electiveUnits" cdkDrag class="unit">
-          <p >
+          <p>
             <strong>{{ unit.code }}</strong> - {{ unit.name }}
           </p>
         </div>
@@ -36,7 +36,13 @@
         <div>
           <mat-form-field appearance="fill">
             <mat-label>Enter Unit Code</mat-label>
-            <input class="search-bar" matInput [(ngModel)]="unitCode" name="unitCode" id="unitCode"/>
+            <input
+              class="search-bar"
+              matInput
+              [(ngModel)]="unitCode"
+              name="unitCode"
+              id="unitCode"
+            />
           </mat-form-field>
           <button mat-flat-button class="button" color="primary" type="submit">Add Unit</button>
 
@@ -62,7 +68,7 @@
       </div>
       <!-- Trimester 1 -->
       <div
-      *ngIf="year.trimester1"
+        *ngIf="year.trimester1"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester1"
@@ -72,8 +78,18 @@
       >
         <h5 class="trimester-heading">Trimester 1</h5>
 
-        <div *ngFor="let unit of year.trimester1" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester1"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 0)">
           <mat-icon>delete</mat-icon>
@@ -81,7 +97,7 @@
       </div>
       <!-- Trimester 2 -->
       <div
-      *ngIf="year.trimester2"
+        *ngIf="year.trimester2"
         class="trimester-list"
         cdkDropList
         [cdkDropListData]="year.trimester2"
@@ -91,8 +107,18 @@
       >
         <h5 class="trimester-heading">Trimester 2</h5>
 
-        <div *ngFor="let unit of year.trimester2" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester2"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 1)">
           <mat-icon>delete</mat-icon>
@@ -100,7 +126,7 @@
       </div>
       <!-- Trimester 3 -->
       <div
-      *ngIf="year.trimester3"
+        *ngIf="year.trimester3"
         cdkDropList
         class="trimester-list"
         [cdkDropListData]="year.trimester3"
@@ -110,8 +136,18 @@
       >
         <h5 class="trimester-heading">Trimester 3</h5>
 
-        <div *ngFor="let unit of year.trimester3" cdkDrag class="unit">
+        <div
+          *ngFor="let unit of year.trimester3"
+          cdkDrag
+          class="unit unit-container"
+          cdkDrag
+          [ngClass]="{'completed': isCompleted(unit)}"
+          [cdkDragDisabled]="isCompleted(unit)"
+        >
           <strong>{{ unit.code }}</strong> - {{ unit.name }}
+          <mat-checkbox (click)="toggleCompletion(unit)" class="complete-checkbox">
+            Mark as completed
+          </mat-checkbox>
         </div>
         <button class="delete-button" mat-icon-button (click)="deleteTrimester(i, 2)">
           <mat-icon>delete</mat-icon>

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -1,142 +1,165 @@
-.required-units-container {
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  display: flex;
-  height: 80vh;
-  vertical-align: top;
-  align-items: left;
-  flex-direction: column;
-  width: 100%; /* Fill available space on mobile */
-  max-width: 25vw;
-}
-
-.year-container {
-  margin: 16px;
-  border: 1px solid #337ab7;
-  border-radius: 9px;
-  display: flex;
-  vertical-align: top;
-  flex-direction: column;
-  border-radius: 6px;
-  width: 98%;
-  justify-content: center;
-  align-items: center;
-}
-
-.trimester-list {
-  display: flex;
-  flex-direction: row; /* Makes the items within the list display horizontally */
-  padding: 10px;
-  border-radius: 6px;
-  background-color: rgb(238, 238, 238);
-  margin: 10px;
-  align-items: center;
-  width: 95%;
-}
-
-.unit {
-  padding: 8px;
-  margin: 8px 0 8px 5%;
-  background-color: #357bb9a8;
-  color: white;
-  border-radius: 6px;
-  cursor: move;
-  align-content: center;
-  height: 8vh;
-  width: 90%;
-}
-
-.study-periods-container {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid #337ab7;
-  border-radius: 6px;
-  margin-left: 20px;
-  width: 70vw;
-  align-items: center;
-}
-
-.study-periods-header, .required-units-header, .year-header{
-  background-color: #337ab7;
-  border-radius: 5px 5px 0 0;
-  color: white;
-  height: 40px;
-  align-items: center;
-  display: flex;
-  padding: 0 10px;
-  width: 100%;
-  font-size: 1.2rem; /* Adjust to ensure readability on smaller screens */
-}
-
-.study-periods-title, .required-units-title, .year-title, .electives-title {
-  font-size: 2rem; /* Default font size for larger screens */
-  margin: 0 2%;
-}
-
-.form {
-  margin: 0 2%;
-}
-
-.text {
-  margin: auto 2% auto 2%;
-}
-
-.electives-container {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  margin: auto 0 8px 5%;
-}
-
-mat-form-field {
-  width: 75%;
-
-}
-
-.search-bar {
-  margin: 0 1% 0 1%;
-  width: 70%;
-}
-
-.button {
-  border-radius: 5px;
-  margin: 0 2% 2% 2%;
-}
-
 .coursemap {
   display: flex;
   flex-direction: row;
+  gap: 20px;
+  width: 80%;
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+  max-height: 90vh;
+}
+
+/* Required Units Panel */
+.required-units-container {
+  width: 25%;
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.completed {
+  text-decoration: line-through;
+  color: grey;
+}
+
+.required-units-title, .electives-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.unit {
+  background: #e3e7ed;
+  padding: 10px;
+  margin: 5px 0;
+  border-radius: 5px;
+  cursor: grab;
+  transition: background 0.3s;
+}
+
+.unit-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.complete-checkbox {
+  margin-left: auto; /* Ensure the checkbox stays on the far right */
+  cursor: pointer;
+}
+
+.unit:hover {
+  background: #d0d4db;
+}
+
+.search-bar {
+  width: 100%;
+  padding: 8px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+.button {
+  margin-top: 10px;
+  width: 100%;
+  background-color: #007bff;
+  color: white;
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: #0056b3;
+}
+
+/* Study Periods Panel */
+.study-periods-container {
+  width: 70%;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.year-container {
+  background: #f9fafc;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.year-title {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.trimester-list {
+  background: #eef1f6;
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .trimester-heading {
-  margin-right: 20px;
-  align-items: center;
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .delete-button {
-  margin-left: auto;
-  right: 2%;
-  display: flex;
-  flex-shrink: 1;
+  background: none;
+  border: none;
+  color: red;
+  cursor: pointer;
 }
 
-@media only screen and (max-width: 775px) {
-  .study-periods-title, .required-units-title, .year-title, .electives-title {
-    font-size: 2.7vw;
-  }
-
-  .text {
-    margin: auto 2% auto 2%;
-    font-size: 1.7vw;
-  }
-
-  .unit {
-    font-size: 1.65vw;
-  }
-
-
+.add-button {
+  display: block;
+  width: 100%;
+  background: #28a745;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  margin-top: 10px;
 }
 
+.add-button:hover {
+  background: #218838;
+}
 
+.completed {
+  text-decoration: line-through;
+  color: grey;
+  opacity: 0.7;
+  cursor: pointer;
+}
 
+.checkmark {
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.inactive {
+  color: lightgray;
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .coursemap {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .required-units-container, .study-periods-container {
+    width: 100%;
+  }
+}

--- a/src/app/courseflow/coursemap/coursemap.component.scss
+++ b/src/app/courseflow/coursemap/coursemap.component.scss
@@ -27,7 +27,7 @@
   color: grey;
 }
 
-.required-units-title, .electives-title {
+.required-units-title, .electives-title .study-periods-title {
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 10px;

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -333,14 +333,14 @@ export class CoursemapComponent implements OnInit {
       return;
     }
 
-    const alreadyAdded = this.electiveUnits.some(unit => unit.code === this.unitCode);
+    const alreadyAdded = this.electiveUnits.some((unit) => unit.code === this.unitCode);
 
     if (alreadyAdded) {
       this.errorMessage = 'Unit already added';
       return;
     }
 
-    const foundUnit = this.units.find(unit => unit.code === this.unitCode);
+    const foundUnit = this.units.find((unit) => unit.code === this.unitCode);
 
     if (foundUnit) {
       this.electiveUnits.push(foundUnit);

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -92,13 +92,14 @@ export class CoursemapComponent implements OnInit {
   // Temporarily creating a course until database is populated with real data
   testCourse: Course = {
     id: '12345',
-    name: 'Introduction to Programming',
-    code: 'CS101',
+    name: 'Bachelor of Cyber Security',
+    code: 'S334',
     year: 2024,
     version: 'v1.0',
-    url: 'http://university.edu/courses/cs101',
+    url: 'http://example.com',
   };
 
+  completedUnits: Set<string> = new Set(); // Stores completed unit codes
 
   ngOnInit(): void {
     this.formData = {
@@ -123,7 +124,7 @@ export class CoursemapComponent implements OnInit {
     this.courseService.getCourses().subscribe({
       next: (data: Course[]) => {
         this.courses = data;
-        console.log('Courses:', this.courses); // Optional: Log the courses to verify
+        console.log('Courses:', this.testCourse); // Optional: Log the courses to verify
       },
       error: (err) => {
         this.errorMessage = 'Error fetching courses';
@@ -166,7 +167,7 @@ export class CoursemapComponent implements OnInit {
       },
     })
     //temporarily create coursemap with id of 1 until database is loaded
-    this.courseMapService.addCourseMap(1,1);
+    this.courseMapService.addCourseMap(1, 1);
     //add empty units to coursemap to initialise study periods
     this.courseMapUnitService.getCourseMapUnitsById(1).subscribe(
       (data: CourseMapUnit[]) => {
@@ -183,7 +184,7 @@ export class CoursemapComponent implements OnInit {
   populateYearsArray(courseMapUnits: CourseMapUnit[]) {
     this.years = [];
 
-    courseMapUnits.forEach(unit => {
+    courseMapUnits.forEach((unit) => {
       console.log('Processing unit with yearSlot:', unit.yearSlot); // Log the yearSlot value
 
       // Find the year object with the same yearSlot value
@@ -309,10 +310,21 @@ export class CoursemapComponent implements OnInit {
         event.previousIndex,
         event.currentIndex,
       );
-
-
     }
+  }
 
+  // Toggle completion state
+  toggleCompletion(unit: UnitDefinition) {
+    if (this.completedUnits.has(unit.code)) {
+      this.completedUnits.delete(unit.code);
+    } else {
+      this.completedUnits.add(unit.code);
+    }
+  }
+
+  // Check if a unit is completed
+  isCompleted(unit: UnitDefinition): boolean {
+    return this.completedUnits.has(unit.code);
   }
 
   fetchUnitByCode(): void {
@@ -339,5 +351,4 @@ export class CoursemapComponent implements OnInit {
       this.unit = null;
     }
   }
-
 }

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -315,11 +315,11 @@ export class CoursemapComponent implements OnInit {
 
   // Toggle completion state
   toggleCompletion(unit: UnitDefinition) {
-    if (this.completedUnits.has(unit.code)) {
-      this.completedUnits.delete(unit.code);
-    } else {
-      this.completedUnits.add(unit.code);
-    }
+    this.completedUnits.has(unit.code)
+      ? this.completedUnits.delete(unit.code)
+      : this.completedUnits.add(unit.code);
+
+    console.log('Completed units:', this.completedUnits);
   }
 
   // Check if a unit is completed

--- a/src/app/courseflow/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/coursemap/coursemap.component.ts
@@ -318,8 +318,7 @@ export class CoursemapComponent implements OnInit {
     this.completedUnits.has(unit.code)
       ? this.completedUnits.delete(unit.code)
       : this.completedUnits.add(unit.code);
-
-    console.log('Completed units:', this.completedUnits);
+      console.log('Completed units:', this.completedUnits);
   }
 
   // Check if a unit is completed


### PR DESCRIPTION
# Description

This feature adds the capability to mark units as "complete" within the study period container. Once a unit is marked as complete, it is no longer draggable or moveable between containers, ensuring that completed units are locked in place and cannot be mistakenly altered. This helps maintain the integrity of the study schedule and prevents unintentional changes to completed tasks.
Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

How to test the feature:
- Fork this pr: https://github.com/doubtfire-lms/doubtfire-api/pull/448
- Then generate testing unit_definion data by using listed rake command
- Elective units only fetching while you are using administrator

I have tested the feature in the following environments:
- Marked units as complete and verified they cannot be dragged or dropped in any study period container.
- Verified that units not marked as complete remain draggable as expected.

Screenshot:
<img width="1861" height="952" alt="Screenshot 2025-08-03 185449" src="https://github.com/user-attachments/assets/1d7508f1-2568-4a7d-8ce0-01895fd758a4" />

## Testing Checklist:

- [X] Tested in latest Chrome
- [ ] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
