### PR TITLE
Feature: add the ability to mark unit as complete and skill summary component in refactor codebase

### DIFF
--- a/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.html
+++ b/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.html
@@ -1,0 +1,65 @@
+<div class="skills-summary-dialog">
+  <div class="dialog-header">
+    <h2 mat-dialog-title>Skills Summary</h2>
+    <button mat-icon-button (click)="onClose()" class="close-button">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <div mat-dialog-content class="dialog-content">
+    <!-- Completed Units Section -->
+    <div class="section" *ngIf="getCompletedUnits().length > 0">
+      <h3 class="section-title">
+        <mat-icon class="section-icon completed">check_circle</mat-icon>
+        Skills Acquired ({{ getCompletedUnits().length }} completed units)
+      </h3>
+      <div class="units-list">
+        <div *ngFor="let unit of getCompletedUnits()" class="unit-item completed">
+          <div class="unit-header">
+            <strong>{{ unit.code }} - {{ unit.name }}</strong>
+            <mat-icon class="status-icon">check_circle</mat-icon>
+          </div>
+          <div class="unit-description" *ngIf="unit.description">
+            {{ unit.description }}
+          </div>
+          <div class="no-description" *ngIf="!unit.description">
+            <em>No skills description available for this unit.</em>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- In Progress Units Section -->
+    <div class="section" *ngIf="getInProgressUnits().length > 0">
+      <h3 class="section-title">
+        <mat-icon class="section-icon in-progress">schedule</mat-icon>
+        Skills in Development ({{ getInProgressUnits().length }} units in progress)
+      </h3>
+      <div class="units-list">
+        <div *ngFor="let unit of getInProgressUnits()" class="unit-item in-progress">
+          <div class="unit-header">
+            <strong>{{ unit.code }} - {{ unit.name }}</strong>
+            <mat-icon class="status-icon">schedule</mat-icon>
+          </div>
+          <div class="unit-description" *ngIf="unit.description">
+            {{ unit.description }}
+          </div>
+          <div class="no-description" *ngIf="!unit.description">
+            <em>No skills description available for this unit.</em>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- No Units Message -->
+    <div class="no-units" *ngIf="getAllPlacedUnits().length === 0">
+      <mat-icon class="empty-icon">lightbulb_outline</mat-icon>
+      <h3>No Units Selected</h3>
+      <p>Add units to your course plan to see a summary of skills you'll learn.</p>
+    </div>
+  </div>
+
+  <div mat-dialog-actions class="dialog-actions">
+    <button mat-raised-button color="primary" (click)="onClose()">Close</button>
+  </div>
+</div>

--- a/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.scss
+++ b/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.scss
@@ -1,0 +1,143 @@
+.skills-summary-dialog {
+  max-width: 800px;
+  width: 100%;
+  max-height: 80vh;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px 0;
+  border-bottom: 1px solid #e0e0e0;
+  margin-bottom: 20px;
+
+  h2 {
+    margin: 0;
+    color: #333;
+    font-weight: 500;
+  }
+
+  .close-button {
+    color: #666;
+  }
+}
+
+.dialog-content {
+  padding: 0 24px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.section {
+  margin-bottom: 30px;
+
+  .section-title {
+    display: flex;
+    align-items: center;
+    margin-bottom: 15px;
+    color: #333;
+    font-size: 18px;
+    font-weight: 500;
+
+    .section-icon {
+      margin-right: 8px;
+
+      &.completed {
+        color: #4caf50;
+      }
+
+      &.in-progress {
+        color: #ff9800;
+      }
+    }
+  }
+}
+
+.units-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.unit-item {
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  background-color: #fafafa;
+
+  &.completed {
+    border-left: 4px solid #4caf50;
+    background-color: #f3f9f3;
+  }
+
+  &.in-progress {
+    border-left: 4px solid #ff9800;
+    background-color: #fff8f0;
+  }
+
+  .unit-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+
+    strong {
+      color: #333;
+      font-size: 16px;
+    }
+
+    .status-icon {
+      font-size: 20px;
+
+      &.completed {
+        color: #4caf50;
+      }
+
+      &.in-progress {
+        color: #ff9800;
+      }
+    }
+  }
+
+  .unit-description {
+    color: #555;
+    line-height: 1.6;
+    font-size: 14px;
+  }
+
+  .no-description {
+    color: #999;
+    font-style: italic;
+    font-size: 14px;
+  }
+}
+
+.no-units {
+  text-align: center;
+  padding: 40px 20px;
+  color: #666;
+
+  .empty-icon {
+    font-size: 48px;
+    color: #ccc;
+    margin-bottom: 16px;
+  }
+
+  h3 {
+    margin: 0 0 12px 0;
+    color: #555;
+  }
+
+  p {
+    margin: 0;
+    color: #777;
+  }
+}
+
+.dialog-actions {
+  padding: 16px 24px;
+  border-top: 1px solid #e0e0e0;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.ts
+++ b/src/app/courseflow/common/skills-summary-dialog/skills-summary-dialog.component.ts
@@ -1,0 +1,46 @@
+import {Component, Inject} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatDialogModule, MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {CourseUnit} from '../../models/course-map.models';
+
+interface SkillsSummaryData {
+  units: CourseUnit[];
+}
+
+@Component({
+  selector: 'skills-summary-dialog',
+  templateUrl: './skills-summary-dialog.component.html',
+  styleUrls: ['./skills-summary-dialog.component.scss'],
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule],
+})
+export class SkillsSummaryDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<SkillsSummaryDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: SkillsSummaryData,
+  ) {}
+
+  onClose(): void {
+    this.dialogRef.close();
+  }
+
+  getCompletedUnits(): CourseUnit[] {
+    return this.data.units.filter(unit => {
+      const unitWithCompletion = unit as CourseUnit & {isCompleted?: boolean};
+      return unitWithCompletion.isCompleted;
+    });
+  }
+
+  getInProgressUnits(): CourseUnit[] {
+    return this.data.units.filter(unit => {
+      const unitWithCompletion = unit as CourseUnit & {isCompleted?: boolean};
+      return !unitWithCompletion.isCompleted;
+    });
+  }
+
+  getAllPlacedUnits(): CourseUnit[] {
+    return this.data.units.filter(unit => unit !== null);
+  }
+}

--- a/src/app/courseflow/common/unit-card/unit-card.component.html
+++ b/src/app/courseflow/common/unit-card/unit-card.component.html
@@ -1,12 +1,28 @@
-<div class="unit" cdkDrag [cdkDragData]="dragData">
+<div
+  class="unit"
+  [cdkDragDisabled]="isCompleted"
+  cdkDrag
+  [cdkDragData]="dragData"
+  [class.completed]="isCompleted"
+  [class.drag-disabled]="isCompleted"
+>
   <strong>{{ unit.code }}</strong> - {{ unit.name }}
+  <mat-icon *ngIf="isCompleted" class="completion-indicator">check_circle</mat-icon>
 
   <button *ngIf="showMenu" mat-icon-button class="unit-menu-button" [matMenuTriggerFor]="unitMenu">
     <mat-icon>more_vert</mat-icon>
   </button>
 
   <mat-menu #unitMenu="matMenu">
-    <button mat-menu-item (click)="onRemoveUnit()">
+    <button mat-menu-item (click)="onToggleCompletion()">
+      <mat-icon>{{ isCompleted ? 'radio_button_checked' : 'radio_button_unchecked' }}</mat-icon>
+      <span>{{ isCompleted ? 'Mark as Incomplete' : 'Mark as Complete' }}</span>
+    </button>
+    <button mat-menu-item (click)="onShowSkillsSummary()">
+      <mat-icon>lightbulb</mat-icon>
+      <span>Skills Summary</span>
+    </button>
+    <button mat-menu-item (click)="onRemoveUnit()" [disabled]="isCompleted">
       <mat-icon>delete</mat-icon>
       <span>Remove</span>
     </button>

--- a/src/app/courseflow/common/unit-card/unit-card.component.scss
+++ b/src/app/courseflow/common/unit-card/unit-card.component.scss
@@ -26,6 +26,25 @@
     background-color: #f2f2f2;
     transform: translateY(-2px);
   }
+
+  &.completed {
+    background-color: #e8f5e8;
+    border-color: #4caf50;
+
+    &:hover {
+      background-color: #d4edda;
+    }
+  }
+
+  &.drag-disabled {
+    cursor: not-allowed;
+    opacity: 0.8;
+
+    &:hover {
+      transform: none;
+      background-color: #e8f5e8;
+    }
+  }
 }
 
 .unit-menu-button {
@@ -45,4 +64,14 @@
   width: 18px;
   height: 18px;
   line-height: 18px;
+}
+
+.completion-indicator {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  color: #4caf50;
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
 }

--- a/src/app/courseflow/common/unit-card/unit-card.component.ts
+++ b/src/app/courseflow/common/unit-card/unit-card.component.ts
@@ -18,8 +18,29 @@ export class UnitCardComponent {
   @Input() dragData!: any;
   @Input() showMenu = false;
   @Output() removeUnit = new EventEmitter<void>();
+  @Output() toggleCompletion = new EventEmitter<void>();
+  @Output() showSkillsSummary = new EventEmitter<CourseUnit>();
+
+  // Track completion status locally if not available on the unit
+  get isCompleted(): boolean {
+    // Check if unit has a completion property, otherwise use local storage or default to false
+    const unitWithCompletion = this.unit as CourseUnit & {isCompleted?: boolean};
+    return unitWithCompletion.isCompleted || false;
+  }
 
   onRemoveUnit(): void {
+    // Don't allow removal of completed units
+    if (this.isCompleted) {
+      return;
+    }
     this.removeUnit.emit();
+  }
+
+  onToggleCompletion(): void {
+    this.toggleCompletion.emit();
+  }
+
+  onShowSkillsSummary(): void {
+    this.showSkillsSummary.emit(this.unit);
   }
 }

--- a/src/app/courseflow/services/course-map-state.service.ts
+++ b/src/app/courseflow/services/course-map-state.service.ts
@@ -386,4 +386,16 @@ export class CourseMapStateService {
       requiredUnits: units,
     });
   }
+
+  toggleUnitCompletion(unit: CourseUnit): void {
+    // For now, we'll store completion status on the unit object itself
+    // In a real implementation, this might be stored in a service or backend
+    const unitWithCompletion = unit as CourseUnit & {isCompleted?: boolean};
+    unitWithCompletion.isCompleted = !unitWithCompletion.isCompleted;
+
+    // Trigger a state update to ensure components re-render
+    this.updateState({
+      ...this.currentState,
+    });
+  }
 }

--- a/src/app/courseflow/states/coursemap/coursemap.component.html
+++ b/src/app/courseflow/states/coursemap/coursemap.component.html
@@ -31,6 +31,7 @@
       [yearIndex]="yIndex"
       [stateService]="stateService"
       (dropEvent)="handleDrop($event)"
+      (showSkillsSummary)="onShowSkillsSummary($event)"
     >
     </course-year-editor>
 

--- a/src/app/courseflow/states/coursemap/coursemap.component.ts
+++ b/src/app/courseflow/states/coursemap/coursemap.component.ts
@@ -2,11 +2,12 @@ import {Component, OnInit, OnDestroy} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
+import {MatDialog} from '@angular/material/dialog';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {Subject, takeUntil} from 'rxjs';
 import {CourseMapStateService} from '../../services/course-map-state.service';
 import {CourseMapDragDropService} from '../../services/course-map-drag-drop.service';
-import {CourseMapState} from '../../models/course-map.models';
+import {CourseMapState, CourseUnit} from '../../models/course-map.models';
 import {
   UnitService,
   CourseService,
@@ -23,6 +24,7 @@ import {CourseYearEditorComponent} from './directives/course-year-editor/course-
 import {RequiredUnitsListComponent} from './directives/required-units-list/required-units-list.component';
 import {ElectiveUnitsListComponent} from './directives/elective-units-list/elective-units-list.component';
 import {UnitSearchComponent} from './directives/unit-search/unit-search.component';
+import {SkillsSummaryDialogComponent} from '../../common/skills-summary-dialog/skills-summary-dialog.component';
 
 @Component({
   selector: 'coursemap',
@@ -38,6 +40,7 @@ import {UnitSearchComponent} from './directives/unit-search/unit-search.componen
     RequiredUnitsListComponent,
     ElectiveUnitsListComponent,
     UnitSearchComponent,
+    SkillsSummaryDialogComponent,
   ],
   providers: [
     UnitService,
@@ -71,6 +74,7 @@ export class CoursemapComponent implements OnInit, OnDestroy {
     private courseMapUnitService: CourseMapUnitService,
     private authService: AuthenticationService,
     private alerts: AlertService,
+    private dialog: MatDialog,
   ) {
     this.state = this.stateService.currentState;
   }
@@ -251,5 +255,33 @@ export class CoursemapComponent implements OnInit, OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   trackByYear(index: number, year: any): number {
     return year.year;
+  }
+
+  onShowSkillsSummary(unit: CourseUnit): void {
+    // Collect all units placed in the course map
+    const allPlacedUnits: CourseUnit[] = [];
+
+    this.state.years.forEach(year => {
+      Object.keys(year).forEach(key => {
+        if (key.startsWith('trimester')) {
+          const trimester = year[key as keyof typeof year] as (CourseUnit | null)[];
+          if (trimester) {
+            trimester.forEach(u => {
+              if (u) {
+                allPlacedUnits.push(u);
+              }
+            });
+          }
+        }
+      });
+    });
+
+    this.dialog.open(SkillsSummaryDialogComponent, {
+      width: '800px',
+      maxWidth: '90vw',
+      data: {
+        units: allPlacedUnits
+      }
+    });
   }
 }

--- a/src/app/courseflow/states/coursemap/directives/course-year-editor/course-year-editor.component.html
+++ b/src/app/courseflow/states/coursemap/directives/course-year-editor/course-year-editor.component.html
@@ -21,6 +21,7 @@
         [stateService]="stateService"
         (dropEvent)="onTrimesterDrop($event)"
         (deleteTrimester)="deleteTrimester(tIndex)"
+        (showSkillsSummary)="onShowSkillsSummary($event)"
       >
       </trimester-editor>
     </ng-container>

--- a/src/app/courseflow/states/coursemap/directives/course-year-editor/course-year-editor.component.ts
+++ b/src/app/courseflow/states/coursemap/directives/course-year-editor/course-year-editor.component.ts
@@ -2,7 +2,7 @@ import {Component, Input, Output, EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
-import {CourseYear, TRIMESTER_KEYS} from '../../../../models/course-map.models';
+import {CourseYear, CourseUnit, TRIMESTER_KEYS} from '../../../../models/course-map.models';
 import {CourseMapStateService} from '../../../../services/course-map-state.service';
 import {TrimesterEditorComponent} from '../trimester-editor/trimester-editor.component';
 
@@ -19,6 +19,7 @@ export class CourseYearEditorComponent {
   @Input() stateService!: CourseMapStateService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   @Output() dropEvent = new EventEmitter<any>();
+  @Output() showSkillsSummary = new EventEmitter<CourseUnit>();
 
   readonly trimesterKeys = TRIMESTER_KEYS;
 
@@ -45,5 +46,9 @@ export class CourseYearEditorComponent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onTrimesterDrop(event: any): void {
     this.dropEvent.emit(event);
+  }
+
+  onShowSkillsSummary(unit: CourseUnit): void {
+    this.showSkillsSummary.emit(unit);
   }
 }

--- a/src/app/courseflow/states/coursemap/directives/trimester-editor/trimester-editor.component.html
+++ b/src/app/courseflow/states/coursemap/directives/trimester-editor/trimester-editor.component.html
@@ -12,6 +12,8 @@
       [slotIndex]="slotIndex"
       (dropEvent)="onSlotDrop($event)"
       (removeUnit)="onRemoveUnit(slotIndex)"
+      (toggleCompletion)="onToggleCompletion($event)"
+      (showSkillsSummary)="onShowSkillsSummary($event)"
     >
     </unit-slot>
   </div>

--- a/src/app/courseflow/states/coursemap/directives/trimester-editor/trimester-editor.component.ts
+++ b/src/app/courseflow/states/coursemap/directives/trimester-editor/trimester-editor.component.ts
@@ -21,6 +21,7 @@ export class TrimesterEditorComponent {
   @Input() stateService!: CourseMapStateService;
   @Output() dropEvent = new EventEmitter<any>();
   @Output() deleteTrimester = new EventEmitter<void>();
+  @Output() showSkillsSummary = new EventEmitter<CourseUnit>();
 
   readonly slotIndices = [0, 1, 2, 3];
 
@@ -38,6 +39,14 @@ export class TrimesterEditorComponent {
 
   onRemoveUnit(slotIndex: number): void {
     this.stateService.removeUnitFromSlot(this.yearIndex, this.trimesterKey, slotIndex);
+  }
+
+  onToggleCompletion(unit: CourseUnit): void {
+    this.stateService.toggleUnitCompletion(unit);
+  }
+
+  onShowSkillsSummary(unit: CourseUnit): void {
+    this.showSkillsSummary.emit(unit);
   }
 
   trackBySlotIndex(index: number): number {

--- a/src/app/courseflow/states/coursemap/directives/unit-slot/unit-slot.component.html
+++ b/src/app/courseflow/states/coursemap/directives/unit-slot/unit-slot.component.html
@@ -12,6 +12,8 @@
     [dragData]="dragData"
     [showMenu]="true"
     (removeUnit)="onRemoveUnit()"
+    (toggleCompletion)="onToggleCompletion()"
+    (showSkillsSummary)="onShowSkillsSummary($event)"
   >
   </unit-card>
 </div>

--- a/src/app/courseflow/states/coursemap/directives/unit-slot/unit-slot.component.ts
+++ b/src/app/courseflow/states/coursemap/directives/unit-slot/unit-slot.component.ts
@@ -29,6 +29,8 @@ export class UnitSlotComponent {
   @Input() slotIndex!: number;
   @Output() dropEvent = new EventEmitter<any>();
   @Output() removeUnit = new EventEmitter<void>();
+  @Output() toggleCompletion = new EventEmitter<CourseUnit>();
+  @Output() showSkillsSummary = new EventEmitter<CourseUnit>();
 
   get dropListId(): string {
     return `${this.trimesterKey}-${this.yearIndex}-slot-${this.slotIndex}`;
@@ -58,5 +60,15 @@ export class UnitSlotComponent {
 
   onRemoveUnit(): void {
     this.removeUnit.emit();
+  }
+
+  onToggleCompletion(): void {
+    if (this.unit) {
+      this.toggleCompletion.emit(this.unit);
+    }
+  }
+
+  onShowSkillsSummary(unit: CourseUnit): void {
+    this.showSkillsSummary.emit(unit);
   }
 }


### PR DESCRIPTION
# Description

This PR introduces two main enhancements to the codebase:
**1. Mark Unit as Complete (related to this PR: https://github.com/thoth-tech/doubtfire-web/pull/386)**
- Added functionality for users to mark a unit as complete.
- Remove ability to move unit from study period container when marked as complete.

**2. Skill Summary Component**
- Added a new component that displays a summary of skills (Description).
- The summary updates automatically based on the completion status of the chosen unit.

Fixes # (issue)
Refactor Codebase: https://github.com/thoth-tech/doubtfire-web/pull/385
Fetch this PR: https://github.com/thoth-tech/doubtfire-api/pull/71 
Migrate and use this command (rake db:test_data:create_frontend_data) to populate the database
If required units are not populated, use the elective units instead (make sure you are using admin account)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="1330" height="762" alt="image" src="https://github.com/user-attachments/assets/346ce908-85ba-4bd4-b41d-7366ce9cfa7f" />

<img width="798" height="491" alt="image" src="https://github.com/user-attachments/assets/a31e927c-abc7-4001-9b60-b216e3ab9ed9" />

**Tests Performed**
**1. Unit Completion Toggle** 
- Unit status updated (unit displayed as complete).
- Completed unit cannot be remove from study periods 
- Skill summary component updated accordingly.

**2. Skill Summary Component**
- Verified that only completed units contribute to the skill summary.
- Checked that summary updates dynamically when toggling completion state.

## Testing Checklist:

- [X] Tested in latest Chrome
- [ ] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
