### PR TITLE
Fix task viewer routing

### DIFF
--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -11,7 +11,7 @@ import {FUnitsComponent} from './admin/states/units/units.component';
 import {ProjectDashboardComponent} from './projects/states/dashboard/project-dashboard/project-dashboard.component';
 import {UnitRootState} from './units/unit-root-state.component';
 import {ProjectRootState} from './projects/states/project-root-state.component';
-import { TaskViewerState } from './units/task-viewer/task-viewer-state.component';
+import { TaskViewerStateComponent } from './units/task-viewer/task-viewer-state.component';
 import {ScormPlayerComponent} from './common/scorm-player/scorm-player.component';
 import { Ng2ViewDeclaration } from '@uirouter/angular';
 
@@ -408,6 +408,21 @@ const ScormPlayerReviewState: NgHybridStateDeclaration = {
   data: {
     pageTitle: 'Preview Scorm Test',
     roleWhitelist: ['Tutor', 'Convenor', 'Admin'],
+  },
+};
+
+export const TaskViewerState: NgHybridStateDeclaration = {
+  name: 'units/tasks/viewer',
+  url: '/units/:unitId/tasks/viewer',
+  parent: 'unit-root-state',
+  data: {
+    pageTitle: 'Unit Tasks',
+    roleWhitelist: ['Tutor', 'Convenor', 'Admin', 'Auditor'],
+  },
+  views: {
+    unitView: {
+      component: TaskViewerStateComponent,
+    },
   },
 };
 

--- a/src/app/units/task-viewer/task-viewer-state.component.html
+++ b/src/app/units/task-viewer/task-viewer-state.component.html
@@ -14,7 +14,7 @@
       <div class="vertical-spacer"></div>
 
       <!-- Panel 2 -->
-      <div class="vertical-panel w-full h-full">
+      <div class="vertical-panel w-full">
         <div class="flex flex-col h-full" *ngIf="selectedTaskDefinition$ | async as selectedTaskDef">
           <div class="shrink">
             <f-task-details-view [taskDef]="selectedTaskDef" [unit]="unit"></f-task-details-view>

--- a/src/app/units/task-viewer/task-viewer-state.component.scss
+++ b/src/app/units/task-viewer/task-viewer-state.component.scss
@@ -4,7 +4,8 @@
   padding: 8px;
   min-width: 60px;
   width: 450px;
-  height: 100%;
+  // height: 100%;
+  height: 87vh;
 
   &.mobile {
       max-width: 100%;

--- a/src/app/units/task-viewer/task-viewer-state.component.ts
+++ b/src/app/units/task-viewer/task-viewer-state.component.ts
@@ -2,8 +2,6 @@
 import {Component, Input} from '@angular/core';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {TaskDefinition, Unit} from 'src/app/api/models/doubtfire-model';
-import {NgHybridStateDeclaration} from '@uirouter/angular-hybrid';
-
 @Component({
   selector: 'f-task-viewer-state',
   templateUrl: './task-viewer-state.component.html',
@@ -32,18 +30,3 @@ export class TaskViewerStateComponent {
     this.selectedTaskDefinition$.next(null);
   }
 }
-
-export const TaskViewerState: NgHybridStateDeclaration = {
-  name: 'units/tasks/viewer',
-  url: '/units/:unitId/tasks/viewer',
-  parent: 'unit-root-state',
-  data: {
-    pageTitle: 'Unit Tasks',
-    roleWhitelist: ['Tutor', 'Convenor', 'Admin', 'Auditor'],
-  },
-  views: {
-    unitView: {
-      component: TaskViewerStateComponent,
-    },
-  },
-};

--- a/src/app/units/task-viewer/task-viewer-state.component.ts
+++ b/src/app/units/task-viewer/task-viewer-state.component.ts
@@ -34,8 +34,8 @@ export class TaskViewerStateComponent {
 }
 
 export const TaskViewerState: NgHybridStateDeclaration = {
-  name: 'units2/tasks',
-  url: '/tasks/:taskDefId',
+  name: 'units/tasks/viewer',
+  url: '/units/:unitId/tasks/viewer',
   parent: 'unit-root-state',
   data: {
     pageTitle: 'Unit Tasks',


### PR DESCRIPTION
# Description

This PR fixes multiple issues in the 9.x branch:

- Clicking Tasks in the unit dropdown menu now correctly loads the Task Viewer component. Previously, the button appeared unresponsive and the route was not updating.
- Fixed the task list panel so it scrolls independently as expected.
- Resolved an issue with the PDF viewer not displaying correctly.

After fixing routing issue.
<img width="1920" height="1077" alt="Screenshot (1778)" src="https://github.com/user-attachments/assets/1cb3da15-9524-49c5-ab04-7373c0ec04d4" />

After fixing both routing and UI issues.
<img width="1917" height="1083" alt="image" src="https://github.com/user-attachments/assets/6d2617d9-e24f-427e-8b48-475619277d7b" />


## Type of change

- Corrected the UI-Router state configuration to properly register the units/tasks/viewer state.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ensured that the TaskViewerStateComponent is linked to the correct parent state (unit-root-state).
- Manually tested navigation to /units/:id/tasks/viewer while logged in as a Convenor, and confirmed it now loads the Task Viewer correctly instead of redirecting to the home page.

 ## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
