### PR TITLE
Feat/add routing for staff grant extension

### DIFF
--- a/src/app/admin/states/units/units.component.ts
+++ b/src/app/admin/states/units/units.component.ts
@@ -37,7 +37,6 @@ export class FUnitsComponent implements OnInit, AfterViewInit {
   @ViewChild(MatTable, {static: false}) table: MatTable<Unit>;
   @ViewChild(MatSort, {static: false}) sort: MatSort;
   @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
-  @Input() unitID;
   @Input({required: true}) mode: 'admin' | 'tutor' | 'student';
 
   displayedColumns: string[] = [

--- a/src/app/admin/states/units/units.component.ts
+++ b/src/app/admin/states/units/units.component.ts
@@ -37,7 +37,7 @@ export class FUnitsComponent implements OnInit, AfterViewInit {
   @ViewChild(MatTable, {static: false}) table: MatTable<Unit>;
   @ViewChild(MatSort, {static: false}) sort: MatSort;
   @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
-
+  @Input() unitID;
   @Input({required: true}) mode: 'admin' | 'tutor' | 'student';
 
   displayedColumns: string[] = [

--- a/src/app/common/header/task-dropdown/task-dropdown.component.html
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.html
@@ -144,9 +144,11 @@
         <button uiSref="units/analytics" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
           <mat-icon aria-label="Unit Analytics icon" fontIcon="insights"></mat-icon>Analytics
         </button>
-        <button uiSref="units/staff_grant_extension" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item> <!-- Todo @Jason - verify route & params to pass-->
-          <mat-icon aria-label="Staff Grant Extension" fontIcon="schedule"></mat-icon>Staff Grant Extension
-        </button>
+        @if (unitRole.role === 'Tutor' || unitRole.role === 'Convenor' || unitRole.role === 'Admin') {
+          <button uiSref="units/staff_grant_extension" [uiParams]="{unit_id: unitRole.unit.id}" mat-menu-item>
+            <mat-icon aria-label="Staff Grant Extension" fontIcon="schedule"></mat-icon>Extension
+          </button>
+        }
         @if (unitRole.role === 'Convenor' || unitRole.role === 'Admin' || unitRole.role === 'Auditor') {
           <button uiSref="units/admin" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
             <mat-icon aria-label="Unit Administration" fontIcon="admin_panel_settings"></mat-icon>

--- a/src/app/common/header/task-dropdown/task-dropdown.component.html
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.html
@@ -144,6 +144,9 @@
         <button uiSref="units/analytics" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
           <mat-icon aria-label="Unit Analytics icon" fontIcon="insights"></mat-icon>Analytics
         </button>
+        <button uiSref="units/staff_grant_extension" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item> <!-- Todo @Jason - verify route & params to pass-->
+          <mat-icon aria-label="Staff Grant Extension" fontIcon="schedule"></mat-icon>Staff Grant Extension
+        </button>
         @if (unitRole.role === 'Convenor' || unitRole.role === 'Admin' || unitRole.role === 'Auditor') {
           <button uiSref="units/admin" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
             <mat-icon aria-label="Unit Administration" fontIcon="admin_panel_settings"></mat-icon>

--- a/src/app/common/header/task-dropdown/task-dropdown.component.ts
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.ts
@@ -30,6 +30,7 @@ export class TaskDropdownComponent {
     'Tutorial List': 'Tutorials',
     'Unit Administration': 'Admin',
     'Unit Analytics': 'Analytics',
+    'Staff Grant Extension': 'Extension', // Todo @Jason - test
   };
 
   taskDropdownData: { title: string; target: string; visible: any }[];
@@ -39,5 +40,4 @@ export class TaskDropdownComponent {
       this.menuText = this.taskToShortName?.[this.currentActivity] ?? this.currentActivity;
     });
   }
-
 }

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -13,8 +13,8 @@ import {UnitRootState} from './units/unit-root-state.component';
 import {ProjectRootState} from './projects/states/project-root-state.component';
 import { TaskViewerState } from './units/task-viewer/task-viewer-state.component';
 import {ScormPlayerComponent} from './common/scorm-player/scorm-player.component';
-import { UnitAnalyticsComponent } from './units/states/analytics/unit-analytics-route.component'; // Todo @SGE team: Replace with SGE component
 import { Ng2ViewDeclaration } from '@uirouter/angular';
+import { UnitAnalyticsComponent } from './units/states/analytics/unit-analytics-route.component'; // Todo @SGE team: Replace with SGE component
 
 /*
  * Use this file to store any states that are sourced by angular components.
@@ -412,15 +412,24 @@ const ScormPlayerReviewState: NgHybridStateDeclaration = {
   },
 };
 
-const StaffGrantExtensionState: NgHybridStateDeclaration = { // Todo @Jason: Navigating to this route makes the `TaskDropdown` disappear - fix
+const StaffGrantExtensionState: NgHybridStateDeclaration = {
   name: 'units/staff_grant_extension',
-  url: '/units/:unitId/staff_grant_extension',
+  url: '/units/:unit_id/staff_grant_extension',
+  resolve: {
+    unitID: [
+      '$stateParams',
+      function ($stateParams) {
+        return $stateParams.unit_id
+      },
+    ],
+  },
   views: {
     main: {
-      component: UnitAnalyticsComponent, // Todo @SGE team: Replace with SGE component
+      component: FUnitsComponent, // Todo @SGE team: Replace with SGE component - accept `unitID` as @Input
     },
   },
   data: {
+    task: 'Staff Grant Extension',
     pageTitle: 'Staff Grant Extension',
     roleWhitelist: ['Tutor', 'Convenor', 'Admin'],
   },

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -13,6 +13,7 @@ import {UnitRootState} from './units/unit-root-state.component';
 import {ProjectRootState} from './projects/states/project-root-state.component';
 import { TaskViewerState } from './units/task-viewer/task-viewer-state.component';
 import {ScormPlayerComponent} from './common/scorm-player/scorm-player.component';
+import { UnitAnalyticsComponent } from './units/states/analytics/unit-analytics-route.component'; // Todo @SGE team: Replace with SGE component
 import { Ng2ViewDeclaration } from '@uirouter/angular';
 
 /*
@@ -411,6 +412,20 @@ const ScormPlayerReviewState: NgHybridStateDeclaration = {
   },
 };
 
+const StaffGrantExtensionState: NgHybridStateDeclaration = { // Todo @Jason: Navigating to this route makes the `TaskDropdown` disappear - fix
+  name: 'units/staff_grant_extension',
+  url: '/units/:unitId/staff_grant_extension',
+  views: {
+    main: {
+      component: UnitAnalyticsComponent, // Todo @SGE team: Replace with SGE component
+    },
+  },
+  data: {
+    pageTitle: 'Staff Grant Extension',
+    roleWhitelist: ['Tutor', 'Convenor', 'Admin'],
+  },
+};
+
 /**
  * Export the list of states we have created in angular
  */
@@ -433,4 +448,5 @@ export const doubtfireStates = [
   ScormPlayerNormalState,
   ScormPlayerReviewState,
   ScormPlayerStudentReviewState,
+  StaffGrantExtensionState,
 ];


### PR DESCRIPTION
# Description

- This PR contains changes for the `Staff Grant Extension` feature.
- It adds a new item to the `Task Dropdown`, as well as an Angular UIRouter declaration that handles this route
- Important: A placeholder component has been loaded for the new route. Please replace this component with your Staff Grant Extension component, and accept the `unitID` property as `@Input` in your component.

Fixes # (issue)

https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:bd20175d09414f079490a2403f7fca74@thread.tacv2_p_njykIFLDn0iAY1at7tACfcgADgBS_h_1714385623719?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fplan%2FnjykIFLDn0iAY1at7tACfcgADgBS%2Fview%2Fgrid%2Ftask%2FHAq4VPQ8U0yqkqNm4Y5QKcgAMSa0%22%2C%22channelId%22%3A%2219%3Abd20175d09414f079490a2403f7fca74%40thread.tacv2%22%7D

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Logging in as `student_1`, `atutor`, `aconvenor`, `aadmin`
2. Verifying the when logged in as `student_1`, the `Staff Grant Extension` dropdown item was not accessible
3. Verifying that when pasting the `Staff Grant Extension` URL in the address bar and navigating to it, I would be redirected to the `Unauthorised` page when logged in as `student_1`

# Screenshots

<img width="572" height="649" alt="Screenshot 2025-09-02 225626" src="https://github.com/user-attachments/assets/2b4c19d4-6ba7-4e9b-883d-83c6052e4e1d" />
<img width="1665" height="777" alt="Screenshot 2025-09-02 225632" src="https://github.com/user-attachments/assets/b28049e9-ad0c-43e9-a5d7-a87c75176778" />

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
