### PR TITLE
chore: upstream synchronization action for forks

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,22 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    # Run at 12AM every night, direct workflow dispatch, and on pull request creation
+    - cron: '0 0 * * *'
+  workflow_dispatch: { }
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ vars.AUTOSYNC_UPSTREAM == 'true' }}
+    steps:
+      - name: Sync branch with upstream
+        run: gh repo sync $REPOSITORY -b $BRANCH_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -15,11 +15,11 @@ jobs:
     permissions:
       contents: write
     outputs:
-	  sync_message: ${{ steps.ghsync.outputs.ghsync-out }}
+	  sync_message: ${{ steps.ghsync.outputs.ghsync_out }}
     steps:
       - name: Sync branch with upstream
 	    id: ghsync
-        run: echo "ghsync-out=$(gh repo sync $REPOSITORY -b $BRANCH_NAME)" >> $GITHUB_OUTPUT
+        run: echo "ghsync_out=$(gh repo sync $REPOSITORY -b $BRANCH_NAME)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -14,12 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      sync_message: ${{ steps.ghsync.outputs.ghsync_out }}
     steps:
       - name: Sync branch with upstream
         id: ghsync
-        run: echo "ghsync_out=$(gh repo sync $REPOSITORY -b $BRANCH_NAME)" >> $GITHUB_OUTPUT
+        run: echo "gh repo sync $REPOSITORY -b $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Sync branch with upstream
         id: ghsync
-        run: echo "gh repo sync $REPOSITORY -b $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
+        run: gh repo sync $REPOSITORY -b $BRANCH_NAME >> $GITHUB_STEP_SUMMARY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -15,10 +15,10 @@ jobs:
     permissions:
       contents: write
     outputs:
-	  sync_message: ${{ steps.ghsync.outputs.ghsync_out }}
+      sync_message: ${{ steps.ghsync.outputs.ghsync_out }}
     steps:
       - name: Sync branch with upstream
-	    id: ghsync
+        id: ghsync
         run: echo "ghsync_out=$(gh repo sync $REPOSITORY -b $BRANCH_NAME)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -4,18 +4,22 @@ on:
   schedule:
     # Run at 12AM every night, direct workflow dispatch, and on pull request creation
     - cron: '0 0 * * *'
-  workflow_dispatch: { }
+  workflow_dispatch:
+  push:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
 jobs:
   sync:
+    if: ${{ vars.AUTOSYNC_UPSTREAM == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ vars.AUTOSYNC_UPSTREAM == 'true' }}
+    outputs:
+	  sync_message: ${{ steps.ghsync.outputs.ghsync-out }}
     steps:
       - name: Sync branch with upstream
-        run: gh repo sync $REPOSITORY -b $BRANCH_NAME
+	    id: ghsync
+        run: echo "ghsync-out=$(gh repo sync $REPOSITORY -b $BRANCH_NAME)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
# Description

Adds a workflow action to automatically sync branches with upstream. Synchronization is performed nightly at 12AM, on PR opening/closing, and commits into PR'd branches.

This ensures pull requests based off toth-tech branches can be merged upstream without risk of merge conflicts. Should also slightly reduce repo maintainer workload, as synchronization will be done automatically.

I'll mirror this PR to all the other doubtfire repositories if approved

### IMPORTANT
This checks a github workflow variable which is disabled/undefined by default, a repo maintainer/administrator will need to create a github action variable `AUTOSYNC_UPSTREAM` with the value `true` to enable this. 

### Caveat
Ironically, this workflow would temporarily(?) break 1:1 parity with upstream as the script needs to be present in the target branch (currently 10.0.x). All that means is putting up with '1 commit ahead' until this is (hopefully) merged upstream. If this is too much of a concern though, I can try to get it merged upstream first.

## Type of change

- [x] New feature 
- [x] This change requires a documentation update

# How Has This Been Tested?

Actions were ran sucessfully on fork. Functionality can be tested by opening a PR into a branch that contains this workflow (or triggering via cron). Once the action has been triggered once, it's registered in github actions and can be manually dispatched.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
