### PR TITLE
doc/readme migration progress update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Important: When completing a frontend migration, please update the below list re
 - [x] ./src/app/common/alert-list/alert-list.coffee
 - [x] ./src/app/common/modals/progress-modal/progress-modal.coffee
 - [x] ./src/app/errors/states/not-found/not-found.coffee
-- [x] ./src/app/groups/tutor-group-manager/tutor-group-manager.coffee
 - [x] ./src/app/common/services/media-service.coffee
 
 ### MIGRATED:
@@ -170,7 +169,7 @@ Important: When completing a frontend migration, please update the below list re
 - [ ] ./src/app/visualisations/alignment-bullet-chart.coffee (ILO Alignments removed)
 - [x] ./src/app/groups/group-member-contribution-assigner/group-member-contribution-assigner.coffee
 - [x] ./src/app/groups/groups.coffee
-- [x] ./src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee (9.x)
+- [x] ./src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee
 
 ### TO REMOVE IN 10.0.x
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Important: When completing a frontend migration, please update the below list re
 - [x] ./src/app/groups/groups.coffee
 - [x] ./src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee (9.x)
 
-### To be removed from 10.0.x
+### TO REMOVE IN 10.0.x
 
 - [ ] ./src/app/projects/project-outcome-alignment/project-outcome-alignment.coffee (Removed in 10.0.x)
 - [ ] ./src/app/projects/states/outcomes/outcomes.coffee

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Important: When completing a frontend migration, please update the below list re
 
 ### SUMMARY:
 
-- `89 / 183` components migrated
-- `19` components no longer in the doubtfire-lms/9.x branch
+- `125 / 185` components migrated
+
+- `21` components no longer in the doubtfire-lms/9.x branch
 
 ### NO LONGER IN doubtfire-lms/9.x
 
@@ -41,6 +42,7 @@ Important: When completing a frontend migration, please update the below list re
 - [x] ./src/app/common/modals/progress-modal/progress-modal.coffee
 - [x] ./src/app/errors/states/not-found/not-found.coffee
 - [x] ./src/app/groups/tutor-group-manager/tutor-group-manager.coffee
+- [x] ./src/app/common/services/media-service.coffee
 
 ### MIGRATED:
 
@@ -157,17 +159,6 @@ Important: When completing a frontend migration, please update the below list re
 - [x] ./src/app/projects/states/tutorials/tutorials.coffee
 - [x] ./src/app/admin/modals/modals.coffee
 - [x] ./src/app/common/services/date-service.coffee
-- [ ] ./src/app/tasks/task-ilo-alignment/modals/task-ilo-alignment-modal/task-ilo-alignment-modal.coffee (Removed in 10.0.x)
-- [ ] ./src/app/tasks/task-ilo-alignment/modals/task-ilo-alignment.coffee (Removed in 10.0.x)
-- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-editor/task-ilo-alignment-editor.coffee (Removed in 10.0.x)
-- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-rater/task-ilo-alignment-rater.coffee (Removed in 10.0.x)
-- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-viewer/task-ilo-alignment-viewer.coffee (Removed in 10.0.x)
-- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment.coffee (Removed in 10.0.x)
-- [ ] ./src/app/projects/project-outcome-alignment/project-outcome-alignment.coffee (Removed in 10.0.x)
-- [ ] ./src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.coffee (Removed in 10.0.x)
-- [ ] ./src/app/units/states/edit/directives/unit-ilo-editor/unit-ilo-editor.coffee (Removed in 10.0.x)
-- [ ] ./src/app/projects/states/outcomes/outcomes.coffee (Removed in 10.0.x)
-- [ ] ./src/app/projects/states/portfolio/directives/portfolio-tasks-step/portfolio-tasks-step.coffee (Removed in 10.0.x)
 - [x] ./src/app/units/states/rollover/directives/directives.coffee
 - [x] ./src/app/units/states/rollover/directives/unit-dates-selector/unit-dates-selector.coffee
 - [x] ./src/app/units/states/rollover/rollover.coffee
@@ -179,6 +170,21 @@ Important: When completing a frontend migration, please update the below list re
 - [ ] ./src/app/visualisations/alignment-bullet-chart.coffee (ILO Alignments removed)
 - [x] ./src/app/groups/group-member-contribution-assigner/group-member-contribution-assigner.coffee
 - [x] ./src/app/groups/groups.coffee
+- [x] ./src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee (9.x)
+
+### To be removed from 10.0.x
+
+- [ ] ./src/app/projects/project-outcome-alignment/project-outcome-alignment.coffee (Removed in 10.0.x)
+- [ ] ./src/app/projects/states/outcomes/outcomes.coffee
+- [ ] ./src/app/projects/states/portfolio/directives/portfolio-tasks-step/portfolio-tasks-step.coffee
+- [ ] ./src/app/tasks/task-ilo-alignment/modals/task-ilo-alignment.coffee (Removed in 10.0.x)
+- [ ] ./src/app/tasks/task-ilo-alignment/modals/task-ilo-alignment-modal/task-ilo-alignment-modal.coffee (Removed in 10.0.x)
+- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment.coffee (Removed in 10.0.x)
+- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-editor/task-ilo-alignment-editor.coffee (Removed in 10.0.x)
+- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-rater/task-ilo-alignment-rater.coffee (Removed in 10.0.x)
+- [ ] ./src/app/tasks/task-ilo-alignment/task-ilo-alignment-viewer/task-ilo-alignment-viewer.coffee (Removed in 10.0.x)
+- [ ] ./src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.coffee (Removed in 10.0.x)
+- [ ] ./src/app/units/states/edit/directives/unit-ilo-editor/unit-ilo-editor.coffee (Removed in 10.0.x)
 
 ### TODO:
 
@@ -189,7 +195,6 @@ Important: When completing a frontend migration, please update the below list re
 - [ ] ./src/app/common/modals/modals.coffee
 - [ ] ./src/app/common/services/analytics-service.coffee
 - [ ] ./src/app/common/services/listener-service.coffee
-- [ ] ./src/app/common/services/media-service.coffee
 - [ ] ./src/app/common/services/outcome-service.coffee
 - [ ] ./src/app/common/services/recorder-service.coffee
 - [ ] ./src/app/common/services/services.coffee
@@ -205,7 +210,6 @@ Important: When completing a frontend migration, please update the below list re
 - [ ] ./src/app/projects/projects.coffee
 - [ ] ./src/app/projects/states/dashboard/dashboard.coffee
 - [ ] ./src/app/projects/states/dashboard/directives/directives.coffee
-- [ ] ./src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee
 - [ ] ./src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
 - [ ] ./src/app/projects/states/feedback/feedback.coffee
 - [ ] ./src/app/projects/states/groups/groups.coffee (State only -> "project-groups")


### PR DESCRIPTION
# Description

Migration progress has been updated to reflect the current state of the 9.x branch. Files that have been flagged as not used/required within 10.0.x have been separated to make clear that removal has not yet occurred. i.e. the files are still present in both 9.x and 10.0.x as at the time of this PR.

## Type of change

- [x] Documentation (update)

## How Has This Been Tested?

The updated content has been tested against the thoth-tech/doubtfire-web: 9.x, thoth-tech/doubtfire-web: 10.0.x, doubtfire-lms/doubtfire-web: 9.x and doubtfire-lms/doubtfire-web: 10.0.x branches. The migration_progress script output was also compared however the output results cannot be simply copied across as it does not account for those files completed within 10.0.x.
The actual changes of this PR have been tested through the file previews to ensure the display aligns with existing formatting structures.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [x] Tested in latest Edge
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox
- [ ] npm run build
- [ ] npm run preview

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


## Files Modified

- Modified:
  - [x] README.md