### PR TITLE
Migration/groups.coffee

### DIFF
--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -53,7 +53,6 @@ import 'build/src/app/config/routing/routing.js';
 import 'build/src/app/config/vendor-dependencies/vendor-dependencies.js';
 import 'build/src/app/config/analytics/analytics.js';
 import 'build/src/app/projects/projects.js';
-import 'build/src/app/projects/states/groups/groups.js';
 import 'build/src/app/projects/states/feedback/feedback.js';
 import 'build/src/app/projects/states/states.js';
 import 'build/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.js';

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -17,7 +17,7 @@ import { Ng2ViewDeclaration } from '@uirouter/angular';
 import { TutorialsComponent } from './projects/states/tutorials/tutorials.component';
 import {PortfoliosComponent} from './units/states/portfolios/portfolios.component';
 import { RolloverComponent } from './units/states/rollover/rollover.component';
-
+import { ProjectGroupsComponent } from './projects/states/groups/project-groups/project-groups.component';
 /*
  * Use this file to store any states that are sourced by angular components.
  */
@@ -456,6 +456,20 @@ const PortfoliosState: NgHybridStateDeclaration = {
   },
 };
 
+const ProjectGroupsState: NgHybridStateDeclaration = {
+  name: 'projects/groups',
+  parent: 'projects2',
+  url: '/groups',
+  views: {
+    projectView: {
+      component: ProjectGroupsComponent,
+    },
+  },
+  data: {
+    task: 'Groups List',
+    pageTitle: 'Unit Groups',
+  },
+};
 
 const RolloverState: NgHybridStateDeclaration = {
   name: 'units/rollover',
@@ -505,4 +519,5 @@ export const doubtfireStates = [
   TutorialState,
   PortfoliosState,
   RolloverState,
+  ProjectGroupsState,
 ];

--- a/src/app/projects/states/groups/project-groups/project-groups.component.html
+++ b/src/app/projects/states/groups/project-groups/project-groups.component.html
@@ -1,6 +1,6 @@
-<div class="container">
-  @if (unit.hasGroupwork()) {
-    <f-group-set-manager [project]="project" [unit]="unit" [selectedGroupSet]="selectedGroupSet">
+<div class="container" *ngIf="project$ | async as project">
+  @if (project.unit.hasGroupwork()) {
+    <f-group-set-manager [project]="project" [unit]="project.unit" [selectedGroupSet]="selectedGroupSet">
     </f-group-set-manager>
   } @else {
     <div class="flex flex-col justify-center items-center max-w-4xl mx-auto">

--- a/src/app/projects/states/groups/project-groups/project-groups.component.ts
+++ b/src/app/projects/states/groups/project-groups/project-groups.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {GroupSet, Project} from 'src/app/api/models/doubtfire-model';
-import {Unit} from 'src/app/api/models/unit';
+import { Observable } from 'rxjs';
 
 // This component is only displayed to students (projects)
 @Component({
@@ -9,7 +9,6 @@ import {Unit} from 'src/app/api/models/unit';
   styleUrl: './project-groups.component.scss',
 })
 export class ProjectGroupsComponent {
-  @Input() unit: Unit;
-  @Input() project: Project;
+  @Input() project$: Observable<Project>;
   @Input() selectedGroupSet: GroupSet;
 }

--- a/src/app/projects/states/states.coffee
+++ b/src/app/projects/states/states.coffee
@@ -2,6 +2,5 @@ angular.module('doubtfire.projects.states', [
   'doubtfire.projects.states.index'
   'doubtfire.projects.states.dashboard'
   'doubtfire.projects.states.portfolio'
-  'doubtfire.projects.states.groups'
   'doubtfire.projects.states.outcomes'
 ])


### PR DESCRIPTION
# Description

This PR migrates the student **Groups List** state from legacy CoffeeScript/AngularJS to TypeScript/Angular. This move completes the transition of the student-facing group management interface to the modern Angular framework.

The state has been updated to sit under the `projects2` parent state, inheriting the project data via the standard `project$` observable pattern used across the repository. This resolved initial `TypeError` issues by ensuring that the component only renders once the unit data has been successfully resolved.

**Key Changes:**
* Removed legacy `projects/states/groups/groups.coffee` and `groups.tpl.html`.
* Defined the `projects/groups` state in `doubtfire.states.ts` as a child of `projects2`.
* Updated `ProjectGroupsComponent` and its template to handle the `project$` observable resolve, matching the architecture of the `ProjectDashboardComponent`.
* Unlinked the `doubtfire.projects.states.groups` module from the AngularJS bootstrap process.

Fixes # (migration)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The migration was verified by testing the end-to-end workflow between Staff and Student roles:

1. **Admin Setup:** Logged in as a **Convenor**, navigated to **Unit Administration** -> **Groups**, and created a new Group Set with student-creation enabled.
2. **Student Navigation:** Logged in as a **Student**, selected the subject from the Home Page, and used the header task dropdown to select **Groups List**.
3. **Data Verification:** Confirmed the new Angular route loaded correctly at `#/projects2/:id/groups`.
4. **Functional Testing:** Verified the student can see existing groups, create a new group, and click **Join** to successfully enter a group.
5. **Edge Case Testing:** Navigated to a unit with no Group Sets enabled and verified the "No Group Work" placeholder message and icon were displayed.

## Screenshots

### Before Migration (AngularJS)
<img width="532" alt="image" src="https://github.com/user-attachments/assets/5b3e4161-1e79-43a2-ba2f-c1822d81684b" />

### After Migration (Angular) - Groups Enabled
<img width="534" alt="image" src="https://github.com/user-attachments/assets/25167396-4269-4b11-a3ac-017c731b2333" />
<img width="534"  alt="image" src="https://github.com/user-attachments/assets/e9ebb2a1-d1fd-44e2-9d4c-d68d5ad2c765" />

### After Migration (Angular) - No Groups 
<img width="534" alt="image" src="https://github.com/user-attachments/assets/a338eed8-daa4-4622-ac54-cd9793bdb842" /> 

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request