### PR TITLE
feat: addition of a button below existing one for the routing to the …

### DIFF
--- a/src/app/home/states/home/home.component.html
+++ b/src/app/home/states/home/home.component.html
@@ -117,18 +117,34 @@
             </mat-card>
           </div>
         </div>
-        <a uiSref="view-all-projects">
-          <button
-            matTooltip="View previous units"
-            matTooltipPosition="above"
-            color="primary"
-            mat-fab
-            extended
-            aria-label="view all projects"
-          >
-            <mat-icon style="color: white">history</mat-icon> View all
-          </button>
-        </a>
+        <!--Start for two buttons All for dashboard and All for all prev Units-->
+        <div class="flex flex-col justify-around items-center h-60">
+          <a uiSref="view-all-projects">
+            <button
+              matTooltip="View previous units"
+              matTooltipPosition="above"
+              color="primary"
+              mat-fab
+              extended
+              aria-label="view all projects"
+            >
+              <mat-icon style="color: white">history</mat-icon> View all
+            </button>
+          </a>
+          <a uiSref="view-all-projects">
+            <button
+              matTooltip="View current units"
+              matTooltipPosition="above"
+              color="primary"
+              mat-fab
+              extended
+              aria-label="view all projects"
+            >
+              <mat-icon style="color: white">dashboard</mat-icon> View all
+            </button>
+          </a>
+        </div>
+        <!--end here so far-->
       </div>
     </div>
   </div>

--- a/src/app/home/states/home/home.component.html
+++ b/src/app/home/states/home/home.component.html
@@ -118,19 +118,7 @@
           </div>
         </div>
         <!--Start for two buttons All for dashboard and All for all prev Units-->
-        <div class="flex flex-col justify-around items-center h-60">
-          <a uiSref="view-all-projects">
-            <button
-              matTooltip="View previous units"
-              matTooltipPosition="above"
-              color="primary"
-              mat-fab
-              extended
-              aria-label="view all projects"
-            >
-              <mat-icon style="color: white">history</mat-icon> View all
-            </button>
-          </a>
+        <div class="flex flex-col justify-around items-start h-60">
           <a uiSref="view-all-projects">
             <button
               matTooltip="View current units"
@@ -141,6 +129,18 @@
               aria-label="view all projects"
             >
               <mat-icon style="color: white">dashboard</mat-icon> View all
+            </button>
+          </a>
+          <a uiSref="view-all-projects">
+            <button
+              matTooltip="View previous units"
+              matTooltipPosition="above"
+              color="primary"
+              mat-fab
+              extended
+              aria-label="view previous projects"
+            >
+              <mat-icon style="color: white">history</mat-icon> View previous
             </button>
           </a>
         </div>


### PR DESCRIPTION
# Description

Strict frontend change in the home component where I added a button underneath the current view all for previous units. This still routes to the same component for previous units, but will be the start for the cross-unit dashboard development

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Run the project locally.
2. Opened the HomePage as a student
3. Changing layouting for responsiveness and routing
4. npm test locally

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
