### PR TITLE
feat: migrate vendor-dependencies from CoffeeScript to TypeScript

### DIFF
--- a/src/app/config/vendor-dependencies/vendor-dependencies.ts
+++ b/src/app/config/vendor-dependencies/vendor-dependencies.ts
@@ -1,0 +1,29 @@
+// Use this module to define all third-party dependencies
+// that are used in Doubtfire
+
+export const vendorDependencies: string[] = [
+  // ng*
+  'ngCsv',
+  'ngSanitize',
+
+  // templates
+  'templates-app',
+
+  // ui.*
+  'ui.router',
+  'ui.router.upgrade',
+  'ui.bootstrap',
+  'ui.codemirror',
+
+  // other libraries
+  'angular.filter',
+  'localization',
+  'markdown',
+  'nvd3',
+  'xeditable',
+  'angular-md5',
+
+  // analytics
+  'angulartics',
+  'angulartics.google.analytics',
+];

--- a/src/app/config/vendor-dependencies/vendor-dependencies.ts
+++ b/src/app/config/vendor-dependencies/vendor-dependencies.ts
@@ -1,7 +1,9 @@
 // Use this module to define all third-party dependencies
 // that are used in Doubtfire
 
-export const vendorDependencies: string[] = [
+import * as angular from 'angular';
+
+export const vendorDependencies = angular.module('doubtfire.config.vendor-dependencies', [
   // ng*
   'ngCsv',
   'ngSanitize',
@@ -26,4 +28,4 @@ export const vendorDependencies: string[] = [
   // analytics
   'angulartics',
   'angulartics.google.analytics',
-];
+]);

--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -55,7 +55,7 @@ import 'build/src/app/config/runtime/runtime.js';
 import 'build/src/app/config/config.js';
 import 'build/src/app/config/root-controller/root-controller.js';
 import 'build/src/app/config/routing/routing.js';
-import 'build/src/app/config/vendor-dependencies/vendor-dependencies.js';
+import './config/vendor-dependencies/vendor-dependencies';
 import 'build/src/app/config/analytics/analytics.js';
 import 'build/src/app/config/debug/debug.js';
 import 'build/src/app/projects/projects.js';


### PR DESCRIPTION
# Description
Migrates the vendor-dependencies module from CoffeeScript (AngularJS) to TypeScript (Angular 17).

The file `vendor-dependencies.coffee` has been rewritten as `vendor-dependencies.ts`, converting the AngularJS module definition to TypeScript while preserving all existing third-party dependencies.

The import in `doubtfire-angularjs.module.ts` has been updated to reference the new TypeScript file directly instead of the compiled JavaScript build output.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
The application was tested locally at localhost:4200. The app loads correctly and login functionality works as expected with the new TypeScript file in place of the old CoffeeScript file.

## Testing Checklist:
- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from team on the Pull Request


old .coffee file
<img width="625" height="675" alt="image" src="https://github.com/user-attachments/assets/643c0fab-0c43-4d08-8b65-38d2948cc24c" />

new .ts file
<img width="622" height="708" alt="image" src="https://github.com/user-attachments/assets/81ef97be-92af-4050-90aa-81a508033962" />

localhost working 
<img width="1919" height="809" alt="image" src="https://github.com/user-attachments/assets/33f3fca1-972f-4036-a48d-b8e44dce9e2e" />
