### PR TITLE
Consolidate outcomes logic into outcomes state and deprecate project-outcome-alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [10.0.1-24](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-23...v10.0.1-24) (2026-03-24)
+
+
+### Features
+
+* confirm recursive fix in mobile tutor view ([b64601a](https://github.com/b0ink/doubtfire-deploy/commit/b64601a425c7a64bccfaf47c1e4fccb0343b1589))
+
 ### [10.0.1-23](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-22...v10.0.1-23) (2026-03-24)
 
 ### [10.0.1-22](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-21...v10.0.1-22) (2026-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [10.0.1-23](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-22...v10.0.1-23) (2026-03-24)
+
 ### [10.0.1-22](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-21...v10.0.1-22) (2026-03-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [10.0.1-25](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-24...v10.0.1-25) (2026-03-26)
+
+
+### Features
+
+* display sso redirecting state ([248c992](https://github.com/b0ink/doubtfire-deploy/commit/248c992f46488f61916e00a87ca32ed987721f31))
+* pause feedback threshold during teaching period breaks ([#1138](https://github.com/b0ink/doubtfire-deploy/issues/1138)) ([12fbf81](https://github.com/b0ink/doubtfire-deploy/commit/12fbf8147107dc185a9a9cbea940efac93a0f316))
+
 ### [10.0.1-24](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-23...v10.0.1-24) (2026-03-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [10.0.1-26](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-25...v10.0.1-26) (2026-03-26)
+
 ### [10.0.1-25](https://github.com/b0ink/doubtfire-deploy/compare/v10.0.1-24...v10.0.1-25) (2026-03-26)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-23",
+  "version": "10.0.1-24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubtfire",
-      "version": "10.0.1-23",
+      "version": "10.0.1-24",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11200,7 +11200,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -16396,9 +16395,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3413,7 +3413,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3495,7 +3497,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7580,7 +7584,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10081,7 +10087,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10253,7 +10261,9 @@
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11200,7 +11210,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -11446,7 +11455,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -11591,7 +11602,9 @@
       }
     },
     "node_modules/globule/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12761,7 +12774,9 @@
       }
     },
     "node_modules/grunt/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14232,7 +14247,9 @@
       "license": "MIT"
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14550,7 +14567,9 @@
       }
     },
     "node_modules/jshint/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14867,7 +14886,9 @@
       }
     },
     "node_modules/karma-coverage-istanbul-reporter/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14938,7 +14959,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16062,7 +16085,9 @@
       }
     },
     "node_modules/multimatch/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21543,7 +21568,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "angular-mocks": "1.8.3",
         "angular-nvd3": "1.0.9",
         "angular-resource": "1.5.11",
-        "angular-sanitize": "1.5.11",
+        "angular-sanitize": "1.8.3",
         "angular-ui-bootstrap": "0.13.4",
         "angular-ui-codemirror": "0.3.0",
         "angular-xeditable": "0.9.0",
@@ -6611,7 +6611,10 @@
       "license": "MIT"
     },
     "node_modules/angular-sanitize": {
-      "version": "1.5.11",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.8.3.tgz",
+      "integrity": "sha512-2rxdqzlUVafUeWOwvY/FtyWk1pFTyCtzreeiTytG9m4smpuAEKaIJAjYeVwWsoV+nlTOcgpwV4W1OCmR+BQbUg==",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
       "license": "MIT"
     },
     "node_modules/angular-ui-bootstrap": {
@@ -11200,7 +11203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-24",
+  "version": "10.0.1-25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubtfire",
-      "version": "10.0.1-24",
+      "version": "10.0.1-25",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-22",
+  "version": "10.0.1-23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubtfire",
-      "version": "10.0.1-22",
+      "version": "10.0.1-23",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-25",
+  "version": "10.0.1-26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubtfire",
-      "version": "10.0.1-25",
+      "version": "10.0.1-26",
       "license": "AGPL-3.0",
       "dependencies": {
         "@angular/animations": "^17.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-24",
+  "version": "10.0.1-25",
   "homepage": "http://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-25",
+  "version": "10.0.1-26",
   "homepage": "http://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "angular-mocks": "1.8.3",
     "angular-nvd3": "1.0.9",
     "angular-resource": "1.5.11",
-    "angular-sanitize": "1.5.11",
+    "angular-sanitize": "1.8.3",
     "angular-ui-bootstrap": "0.13.4",
     "angular-ui-codemirror": "0.3.0",
     "angular-xeditable": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-23",
+  "version": "10.0.1-24",
   "homepage": "http://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubtfire",
-  "version": "10.0.1-22",
+  "version": "10.0.1-23",
   "homepage": "http://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",

--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -152,6 +152,49 @@ export class Task extends Entity {
     return this.project.unit;
   }
 
+  private getBreakOverlapMilliseconds(
+    startTime: number,
+    endTime: number,
+    breaks: readonly {startDate: Date; numberOfWeeks: number}[],
+  ): number {
+    const millisecondsPerDay = 1000 * 60 * 60 * 24;
+
+    return breaks.reduce((overlap, teachingBreak) => {
+      const breakStart = new Date(teachingBreak.startDate).getTime();
+      const breakDuration = (teachingBreak.numberOfWeeks ?? 0) * 7 * millisecondsPerDay;
+      const breakEnd = breakStart + breakDuration;
+
+      if (!Number.isFinite(breakStart) || breakDuration <= 0) {
+        return overlap;
+      }
+
+      const overlapStart = Math.max(startTime, breakStart);
+      const overlapEnd = Math.min(endTime, breakEnd);
+
+      return overlap + Math.max(0, overlapEnd - overlapStart);
+    }, 0);
+  }
+
+  public daysSinceSubmission(nowTime = Date.now()): number {
+    const millisecondsPerDay = 1000 * 60 * 60 * 24;
+    const submissionTime = new Date(this.submissionDate).getTime();
+
+    if (!Number.isFinite(submissionTime) || nowTime <= submissionTime) {
+      return 0;
+    }
+
+    const teachingBreaks = this.unit.teachingPeriod?.breaks ?? [];
+    const pausedMilliseconds = this.getBreakOverlapMilliseconds(
+      submissionTime,
+      nowTime,
+      teachingBreaks,
+    );
+
+    return Math.floor(
+      Math.max(0, nowTime - submissionTime - pausedMilliseconds) / millisecondsPerDay,
+    );
+  }
+
   /**
    * Determine if a task matches a given search text.
    *

--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -24,10 +24,11 @@ import {
 import {Grade} from './grade';
 import {LOCALE_ID} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {Observable, map} from 'rxjs';
+import {Observable, firstValueFrom, map} from 'rxjs';
 import {gradeTaskModal, uploadSubmissionModal} from 'src/app/ajs-upgraded-providers';
 import {AlertService} from 'src/app/common/services/alert.service';
 import {MappingFunctions} from '../services/mapping-fn';
+import {TaskPrerequisite} from './task-prerequisite';
 
 export const FeedbackModerationAction = {
   ShowMore: 'show_more',
@@ -681,6 +682,58 @@ export class Task extends Entity {
       );
   }
 
+  private mapUnitTaskPrerequisites(prerequisites: TaskPrerequisite[]): TaskPrerequisite[] {
+    const definitions = this.unit.taskDefinitions;
+
+    return prerequisites.map((prerequisite) => {
+      prerequisite.taskDefinition = definitions.find(
+        (td) => td.id === prerequisite.taskDefinitionId,
+      );
+      prerequisite.prerequisite = definitions.find((td) => td.id === prerequisite.prerequisiteId);
+      return prerequisite;
+    });
+  }
+
+  private buildProjectTaskForDefinition(definition: TaskDefinition): Task {
+    const dependentTask = new Task(this.project);
+    dependentTask.project = this.project;
+    dependentTask.definition = definition;
+    return dependentTask;
+  }
+
+  private async dependentTaskNeedsRecursiveFix(definition: TaskDefinition): Promise<boolean> {
+    const cachedTask = this.project.findTaskForDefinition(definition.id);
+    if (cachedTask) {
+      return cachedTask.status === 'ready_for_feedback';
+    }
+
+    const dependentTask = this.buildProjectTaskForDefinition(definition);
+    const taskWithSubmissionDetails = await firstValueFrom(dependentTask.getSubmissionDetails());
+    return taskWithSubmissionDetails.status === 'ready_for_feedback';
+  }
+
+  public async hasReadyForFeedbackDependents(): Promise<boolean> {
+    const allPrerequisites = await firstValueFrom(this.unit.getTaskPrerequisites());
+    const dependentPrerequisites = this.mapUnitTaskPrerequisites(allPrerequisites).filter(
+      (prerequisite) => prerequisite.prerequisiteId === this.definition.id,
+    );
+
+    for (const prerequisite of dependentPrerequisites) {
+      if (!prerequisite.taskDefinition) {
+        continue;
+      }
+
+      const shouldTriggerRecursiveFix = await this.dependentTaskNeedsRecursiveFix(
+        prerequisite.taskDefinition,
+      );
+      if (shouldTriggerRecursiveFix) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   public get overseerEnabled(): boolean {
     return this.unit.overseerEnabled && this.definition.assessmentEnabled;
   }
@@ -826,7 +879,11 @@ export class Task extends Entity {
       });
   }
 
-  public updateTaskStatus(status: TaskStatusEnum, markAsDiscussed?: boolean) {
+  public updateTaskStatus(
+    status: TaskStatusEnum,
+    markAsDiscussed?: boolean,
+    triggerRecursiveFix?: boolean,
+  ) {
     const oldStatus = this.status;
     const alerts: AlertService = AppInjector.get(AlertService);
 
@@ -849,6 +906,10 @@ export class Task extends Entity {
 
       if (markAsDiscussed === true) {
         options.body['discussed'] = true;
+      }
+
+      if (triggerRecursiveFix === true) {
+        options.body['trigger_recursive_fix'] = true;
       }
 
       const hasId: boolean = this.id > 0;

--- a/src/app/api/services/task.service.ts
+++ b/src/app/api/services/task.service.ts
@@ -188,6 +188,9 @@ export class TaskService extends CachedEntityService<Task> {
         constructorParams: unit,
       },
     ).pipe(
+      map((tasks: Task[]) =>
+        tasks.filter((t) => t.daysSinceSubmission() >= t.unit.feedbackOverflowThresholdDays),
+      ),
       tap((tasks: Task[]) => {
         unit.incorporateTasks(tasks);
       }),

--- a/src/app/common/footer/footer.component.html
+++ b/src/app/common/footer/footer.component.html
@@ -45,7 +45,7 @@
         matTooltipPosition="above"
         aria-label=""
         class="button large-button"
-        (click)="selectedTask?.updateTaskStatus('fix')"
+        (click)="markAsResubmit(selectedTask)"
       >
         <mat-icon>construction</mat-icon>
       </button>

--- a/src/app/common/footer/footer.component.ts
+++ b/src/app/common/footer/footer.component.ts
@@ -7,6 +7,9 @@ import {FileDownloaderService} from '../file-downloader/file-downloader.service'
 import {TaskAssessmentModalService} from '../modals/task-assessment-modal/task-assessment-modal.service';
 import {UnitRole} from 'src/app/api/models/unit-role';
 import {UserService} from 'src/app/api/services/user.service';
+import {ProjectService} from 'src/app/api/services/project.service';
+import {ConfirmationModalService} from '../modals/confirmation-modal/confirmation-modal.service';
+import {AlertService} from '../services/alert.service';
 
 @Component({
   selector: 'f-footer',
@@ -20,6 +23,9 @@ export class FooterComponent implements OnInit {
     private fileDownloader: FileDownloaderService,
     private taskAssessmentModal: TaskAssessmentModalService,
     private userService: UserService,
+    private projectService: ProjectService,
+    private confirmationModalService: ConfirmationModalService,
+    private alertService: AlertService,
   ) {}
 
   @Input() viewType: 'inbox' | 'explorer' | 'moderation' | 'overflow';
@@ -190,5 +196,35 @@ export class FooterComponent implements OnInit {
 
   public toggleModerationStatusButtons() {
     this.showModerationStatusButtons = !this.showModerationStatusButtons;
+  }
+
+  async markAsResubmit(task: Task) {
+    if (!task?.definition || !task?.project) {
+      return;
+    }
+
+    try {
+      const hasReadyDependents = await task.hasReadyForFeedbackDependents();
+      if (!hasReadyDependents) {
+        task.updateTaskStatus('fix_and_resubmit');
+        return;
+      }
+
+      this.confirmationModalService.show(
+        'Move dependent tasks to Fix and Resubmit?',
+        'This task is a prerequisite for one or more other tasks submitted by this student that are Ready for Feedback. Do you want to move those tasks to Fix and Resubmit as well?',
+        () => {
+          task.updateTaskStatus('fix_and_resubmit', false, true);
+        },
+        () => {
+          task.updateTaskStatus('fix_and_resubmit');
+        },
+        'Yes, update dependent tasks',
+        'No, just this task',
+      );
+    } catch (error) {
+      this.alertService.error(`Failed to check dependent task statuses: ${error}`, 6000);
+      task.updateTaskStatus('fix_and_resubmit');
+    }
   }
 }

--- a/src/app/common/modals/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/common/modals/confirmation-modal/confirmation-modal.component.html
@@ -13,8 +13,8 @@
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button mat-raised-button color="primary" (click)="confirmAction()">
-      <i class="fa fa-check"></i> Confirm
+      <i class="fa fa-check"></i> {{ confirmText }}
     </button>
-    <button mat-button color="warn" (click)="cancelAction()">Cancel</button>
+    <button mat-button color="warn" (click)="cancelAction()">{{ cancelText }}</button>
   </mat-dialog-actions>
 </div>

--- a/src/app/common/modals/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/common/modals/confirmation-modal/confirmation-modal.component.ts
@@ -5,7 +5,10 @@ import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 export interface ConfirmationModalData {
   title: string;
   message: string;
-  action?: any;
+  action?: () => void;
+  cancelAction?: () => void;
+  confirmText?: string;
+  cancelText?: string;
 }
 
 @Component({
@@ -17,6 +20,9 @@ export class ConfirmationModalComponent implements OnInit {
   @Input() title: string;
   @Input() message: string;
   @Input() action: () => void;
+  @Input() cancelActionFn: () => void;
+  @Input() confirmText: string;
+  @Input() cancelText: string;
 
   constructor(
     @Inject(AlertService) private alertService: AlertService,
@@ -29,6 +35,9 @@ export class ConfirmationModalComponent implements OnInit {
     this.title = this.data.title;
     this.message = this.data.message;
     this.action = this.data.action;
+    this.cancelActionFn = this.data.cancelAction;
+    this.confirmText = this.data.confirmText ?? 'Confirm';
+    this.cancelText = this.data.cancelText ?? 'Cancel';
   }
 
   public confirmAction() {
@@ -41,7 +50,11 @@ export class ConfirmationModalComponent implements OnInit {
   }
 
   public cancelAction() {
-    this.alertService.success(`${this.title} action cancelled.`);
+    if (typeof this.cancelActionFn === 'function') {
+      this.cancelActionFn();
+    } else {
+      this.alertService.success(`${this.title} action cancelled.`);
+    }
     this.dialogRef.close();
   }
 }

--- a/src/app/common/modals/confirmation-modal/confirmation-modal.service.ts
+++ b/src/app/common/modals/confirmation-modal/confirmation-modal.service.ts
@@ -11,7 +11,10 @@ export class ConfirmationModalService {
   public show(
     title: string,
     message: string,
-    action?: any,
+    action?: () => void,
+    cancelAction?: () => void,
+    confirmText?: string,
+    cancelText?: string,
   ): MatDialogRef<ConfirmationModalComponent, ConfirmationModalData> {
     return this.dialog.open<ConfirmationModalComponent, ConfirmationModalData>(
       ConfirmationModalComponent,
@@ -20,6 +23,9 @@ export class ConfirmationModalService {
           title,
           message,
           action,
+          cancelAction,
+          confirmText,
+          cancelText,
         },
         position: {top: '2.5%'},
         width: '100%',

--- a/src/app/projects/project-outcome-alignment/project-outcome-alignment.coffee
+++ b/src/app/projects/project-outcome-alignment/project-outcome-alignment.coffee
@@ -1,50 +1,14 @@
-# Component not used
+# Deprecated wrapper for the legacy project-outcome-alignment component.
+# The outcomes feature source of truth is now:
+# projects/states/outcomes/outcomes.coffee
+#
+# This directive is kept temporarily as a thin wrapper to avoid breaking
+# any remaining references during transition. It should be removed once
+# all references are confirmed deleted.
 
 angular.module("doubtfire.projects.project-outcome-alignment", [])
 
 .directive("projectOutcomeAlignment", ->
   restrict: 'E'
   templateUrl: 'projects/project-outcome-alignment/project-outcome-alignment.tpl.html'
-  controller: ($scope, $rootScope, $timeout, outcomeService, alertService, analyticsService, Visualisation, newUnitService) ->
-    $scope.poaView = {
-      activeTab: 'list'
-    }
-    $scope.targets = outcomeService.calculateTargets($scope.unit, $scope.unit, $scope.unit.taskStatusFactor)
-    $scope.currentProgress = outcomeService.calculateProgress($scope.unit, $scope.project)
-
-    $scope.refreshCharts = Visualisation.refreshAll
-
-    refreshAlignmentData = ->
-      $scope.currentProgress.length = 0
-      $scope.currentProgress = _.extend $scope.currentProgress, outcomeService.calculateProgress($scope.unit, $scope.project)
-
-    # $scope.$watch 'project', ->
-    #   refreshAlignmentData()
-    #   $rootScope.$broadcast('ProgressUpdated')
-
-    # $scope.$watch 'project.tasks', ->
-    #   refreshAlignmentData()
-    #   $rootScope.$broadcast('ProgressUpdated')
-
-    $scope.selectTab = (tab) ->
-      if tab is 'progress'
-        if !$scope.classStats?
-          newUnitService.loadLearningProgressClassStats($scope.unit).subscribe({
-            next: (response) -> $scope.classStats = response
-            error: (response) ->
-              alertService.error( response, 6000)
-              $scope.classStats = {}
-          })
-      $scope.poaView.activeTab = tab
-      eventName = if tab is 'progress' then "View Learning Progress Tab" else "Reflect on Learning Tab"
-      $scope.refreshCharts()
-
-    # Default tab
-    $scope.selectTab('progress')
-
-    $scope.$on('UpdateAlignmentChart', ->
-      refreshAlignmentData()
-      $rootScope.$broadcast('ProgressUpdated')
-    )
-
 )

--- a/src/app/projects/projects.coffee
+++ b/src/app/projects/projects.coffee
@@ -1,5 +1,9 @@
+# Parent projects module.
+# Outcomes source of truth now lives in projects.states.outcomes.
+# project-outcome-alignment has been deprecated and removed from the
+# parent dependency list as part of outcomes consolidation.
+
 angular.module('doubtfire.projects', [
   'doubtfire.projects.states'
-  'doubtfire.projects.project-outcome-alignment'
   'doubtfire.projects.project-progress-dashboard'
 ])

--- a/src/app/projects/states/outcomes/outcomes.coffee
+++ b/src/app/projects/states/outcomes/outcomes.coffee
@@ -1,4 +1,7 @@
-# Component not used
+# Source of truth for the outcomes feature.
+# This state owns the route, page-level logic, and template rendering.
+# Outcomes UI has been inlined into outcomes.tpl.html to remove duplicated
+# logic previously shared with project-outcome-alignment.
 
 angular.module('doubtfire.projects.states.outcomes', [])
 
@@ -22,9 +25,9 @@ angular.module('doubtfire.projects.states.outcomes', [])
   $scope.poaView = {
     activeTab: 'list'
   }
+
   $scope.targets = outcomeService.calculateTargets($scope.unit, $scope.unit, $scope.unit.taskStatusFactor)
   $scope.currentProgress = outcomeService.calculateProgress($scope.unit, $scope.project)
-
   $scope.refreshCharts = Visualisation.refreshAll
 
   refreshAlignmentData = ->
@@ -37,11 +40,11 @@ angular.module('doubtfire.projects.states.outcomes', [])
         newUnitService.loadLearningProgressClassStats($scope.unit).subscribe({
           next: (response) -> $scope.classStats = response
           error: (response) ->
-            alertService.error( response, 6000)
+            alertService.error(response, 6000)
             $scope.classStats = {}
         })
+
     $scope.poaView.activeTab = tab
-    eventName = if tab is 'progress' then "View Learning Progress Tab" else "Reflect on Learning Tab"
     $scope.refreshCharts()
 
   # Default tab

--- a/src/app/projects/states/outcomes/outcomes.tpl.html
+++ b/src/app/projects/states/outcomes/outcomes.tpl.html
@@ -1,6 +1,59 @@
 <div class="container" ng-show="unit.ilos.length > 0">
-  <project-outcome-alignment></project-outcome-alignment>
+  <tabset>
+    <tab ng-click="selectTab('progress')">
+      <tab-heading>
+        Outcome Achievement
+      </tab-heading>
+    </tab>
+    <tab ng-click="selectTab('reflect')">
+      <tab-heading>
+        Outcome Alignment
+      </tab-heading>
+    </tab>
+  </tabset><!--/tab-selector-->
+
+  <div class="panel panel-default" ng-show="poaView.activeTab == 'progress'">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        Outcome Achievement
+      </h3>
+    </div>
+    <div class="panel-body view-alignment">
+      Overall progress on unit outcome are shown below
+    </div>
+    <task-ilo-alignment-viewer
+      project="project"
+      unit="unit"
+      class-stats="classStats"
+      current-progress="currentProgress"
+      summary-only="true"></task-ilo-alignment-viewer>
+  </div><!--/achievement-panel-->
+
+  <div class="panel panel-default clearfix" ng-show="poaView.activeTab == 'progress'">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        Visualise Achievement
+      </h3>
+    </div>
+    <div class="panel-body">
+      Your achievement with all ILOs are visualised below
+    </div>
+    <achievement-custom-bar-chart
+      show-legend="false"
+      unit="unit"
+      project="project"
+      class="col-sm-12">
+    </achievement-custom-bar-chart>
+  </div><!--/visualisation-achievement-->
+
+  <div ng-show="poaView.activeTab == 'reflect'">
+    <task-ilo-alignment-editor
+      show-csv="false"
+      unit="unit"
+      project="project"></task-ilo-alignment-editor>
+  </div><!--ilo-editor-->
 </div><!--/ilos-->
+
 <div class="container" ng-hide="unit.ilos.length > 0">
   <div class="large-notice-block">
     <i class="fa fa-2x fa-graduation-cap"></i>
@@ -10,4 +63,3 @@
     There are no learning outcomes for this unit.
   </div>
 </div><!--/no-ilos-->
-

--- a/src/app/projects/states/tutor-discussion/tutor-discussion.component.ts
+++ b/src/app/projects/states/tutor-discussion/tutor-discussion.component.ts
@@ -17,6 +17,7 @@ import {
   UnitService,
   UserService,
 } from 'src/app/api/models/doubtfire-model';
+import {ConfirmationModalService} from 'src/app/common/modals/confirmation-modal/confirmation-modal.service';
 import {AlertService} from 'src/app/common/services/alert.service';
 import {GradeService} from 'src/app/common/services/grade.service';
 
@@ -66,6 +67,7 @@ export class TutorDiscussionComponent implements AfterViewInit {
     private gradeService: GradeService,
     private state: StateService,
     private alertService: AlertService,
+    private confirmationModalService: ConfirmationModalService,
     private route: UIRouter,
     private taskCommentService: TaskCommentService,
     private taskService: TaskService,
@@ -262,7 +264,7 @@ export class TutorDiscussionComponent implements AfterViewInit {
     this.selectedTask = task;
   }
 
-  public setSelectedTasksStatus(status: TaskStatusEnum) {
+  public async setSelectedTasksStatus(status: TaskStatusEnum) {
     const selectedTasks = this.tasksList.selectedOptions.selected.map((taskOption) => {
       return taskOption.value as Task;
     });
@@ -279,6 +281,44 @@ export class TutorDiscussionComponent implements AfterViewInit {
       }
     }
 
+    if (status === 'fix_and_resubmit') {
+      try {
+        const hasReadyDependents = (
+          await Promise.all(
+            selectedTasks.map((task) =>
+              task?.definition && task?.project ? task.hasReadyForFeedbackDependents() : false,
+            ),
+          )
+        ).some(Boolean);
+
+        if (hasReadyDependents) {
+          this.confirmationModalService.show(
+            'Move dependent tasks to Fix and Resubmit?',
+            'One or more selected tasks are prerequisites for other tasks submitted by this student that are Ready for Feedback. Do you want to move those tasks to Fix and Resubmit as well?',
+            () => {
+              this.updateSelectedTasksStatus(selectedTasks, status, true);
+            },
+            () => {
+              this.updateSelectedTasksStatus(selectedTasks, status, false);
+            },
+            'Yes, update dependent tasks',
+            'No, just selected tasks',
+          );
+          return;
+        }
+      } catch (error) {
+        this.alertService.error(`Failed to check dependent task statuses: ${error}`, 6000);
+      }
+    }
+
+    this.updateSelectedTasksStatus(selectedTasks, status, false);
+  }
+
+  private updateSelectedTasksStatus(
+    selectedTasks: Task[],
+    status: TaskStatusEnum,
+    moveDependentTasks: boolean,
+  ) {
     for (const task of selectedTasks) {
       if (
         status === 'complete' &&
@@ -290,6 +330,8 @@ export class TutorDiscussionComponent implements AfterViewInit {
 
       if (task.definition.assessInPortfolioOnly) {
         task.updateTaskStatus(status === 'complete' ? 'working_on_it' : status, true);
+      } else if (status === 'fix_and_resubmit') {
+        task.updateTaskStatus(status, true, moveDependentTasks);
       } else {
         task.updateTaskStatus(status, true);
       }

--- a/src/app/sessions/states/sign-in/sign-in.component.html
+++ b/src/app/sessions/states/sign-in/sign-in.component.html
@@ -57,7 +57,14 @@
               type="form"
               [disabled]="form.invalid"
             >
-              Sign In
+              <div class="flex items-center gap-2">
+                @if (redirectingSSO) {
+                  Signing In...
+                  <mat-spinner diameter="20"></mat-spinner>
+                } @else {
+                  Sign In
+                }
+              </div>
             </button>
           </form>
         </div>

--- a/src/app/sessions/states/sign-in/sign-in.component.ts
+++ b/src/app/sessions/states/sign-in/sign-in.component.ts
@@ -54,6 +54,8 @@ export class SignInComponent implements OnInit {
   public isLoading: boolean = true;
   public authMethodFailed: boolean = false;
 
+  public redirectingSSO: boolean = false;
+
   // Get query params from the resolve in the router state
   @Input() username: string;
   @Input() authToken: string;
@@ -163,10 +165,13 @@ export class SignInComponent implements OnInit {
             });
         } else if (this.SSOLoginUrl) {
           if (this.autoLogin) {
+            this.redirectingSSO = true;
             return wait.then(() => {
               // Double check in case changed in the meantime
               if (this.autoLogin) {
                 this.redirectToSSO();
+              } else {
+                this.redirectingSSO = false;
               }
             });
           } else {

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -269,7 +269,11 @@
                       </mat-icon>
                     } @else if (getWarningIcon(task) === 'overflow') {
                       <mat-icon
-                        matTooltip="Feedback overdue — this task has been escalated for urgent review."
+                        [matTooltip]="
+                          'Feedback overdue by ' +
+                          task.daysSinceSubmission() +
+                          ' days — this task has been escalated for urgent review.'
+                        "
                         class="shrink-0 text-red-500"
                       >
                         watch_later

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
@@ -572,10 +572,7 @@ export class StaffTaskListComponent implements OnInit, OnChanges, OnDestroy {
       return null;
     }
 
-    const now = Date.now();
-    const submission = new Date(task.submissionDate).getTime();
-
-    const daysSinceSubmission = (now - submission) / (1000 * 60 * 60 * 24);
+    const daysSinceSubmission = task.daysSinceSubmission();
 
     if (daysSinceSubmission >= task.unit.feedbackOverflowThresholdDays) {
       return 'overflow';


### PR DESCRIPTION
Title:
Consolidate outcomes logic into outcomes state and deprecate project-outcome-alignment

---

Summary:

This PR consolidates the outcomes feature by making the outcomes state 
(doubtfire.projects.states.outcomes) the single source of truth and removing 
duplicate logic previously shared with the project-outcome-alignment component.

---

Background:

During dependency investigation of the projects module (projects.coffee), it was found that:

- The project-outcome-alignment component is still active, even though it is marked as "not used"
- The same outcomes-related logic exists in both:
  • states/outcomes/outcomes.coffee
  • project-outcome-alignment/project-outcome-alignment.coffee

Both implementations handle:
- target calculation
- progress tracking
- class statistics loading
- chart refresh and update events

This duplication creates a migration blocker because there is no clear source of truth.

---

Changes in this PR:

1. Outcomes state is now the source of truth
   - Retained all outcomes logic inside:
     src/app/projects/states/outcomes/outcomes.coffee

2. Outcomes UI is now rendered directly from the state
   - Replaced:
     <project-outcome-alignment>
     with direct template rendering inside outcomes.tpl.html

3. Removed duplication from project-outcome-alignment
   - Converted it into a thin/deprecated wrapper
   - Removed controller logic to eliminate duplication

4. Updated parent module dependencies
   - Removed:
     doubtfire.projects.project-outcome-alignment
   - Kept only active dependencies

5. Added clear documentation in code
   - Updated misleading comments
   - Documented overlap and consolidation decision

---

What was NOT changed:

- The project-outcome-alignment files are intentionally NOT deleted yet
- The AngularJS module import (if still present) is also left untouched

Reason:
This keeps the PR safe and allows reviewers to confirm that there are no hidden dependencies before full removal.

---

Next Steps (Post Review):

If confirmed by reviewers, we can:

- Remove:
  • project-outcome-alignment.coffee
  • project-outcome-alignment.tpl.html
- Remove import from:
  src/app/doubtfire-angularjs.module.ts
- Run a final cleanup to fully eliminate the deprecated module

---

Impact:

- No functional behaviour changes expected
- Reduces duplication in outcomes feature
- Establishes a clear source of truth
- Removes a confirmed migration blocker
- Improves maintainability and clarity for future refactoring

---

Testing:

- Verified outcomes page loads correctly
- Outcome Achievement tab works
- Outcome Alignment tab works
- No console errors related to module loading

---

Additional Notes:

This PR also confirms a previous task comment stating that 
"project-outcome-alignment may be a blocker". This investigation validates that 
concern, as the duplication directly impacts migration clarity.