### PR TITLE
feat(ai_eff): AI Effort Prediction web changes

### DIFF
--- a/src/app/api/models/project.ts
+++ b/src/app/api/models/project.ts
@@ -404,7 +404,7 @@ export class Project extends Entity {
     const targetTasks = this.unit.taskDefinitionsForGrade(this.targetGrade);
 
     // get total value of all tasks assigned to this project
-    const total = targetTasks.map((td) => td.weighting).reduce((prev, current, idx, array) => prev + current, 0);
+    const total = targetTasks.map((td) => td.estimated_hours).reduce((prev, current, idx, array) => prev + current, 0);
 
     // exit if no tasks or no weights
     if (targetTasks.length === 0 || total === 0) {
@@ -444,7 +444,7 @@ export class Project extends Entity {
       const weeksElapsed = MappingFunctions.weeksBetween(this.unit.startDate, today);
       if (weeksElapsed > 0) {
         const completedTasksWeight = readyOrCompleteTasks
-          .map((t) => t.definition.weighting)
+          .map((t) => t.definition.estimated_hours)
           .reduce((prev, current, idx, arr) => prev + current, 0);
         completionRate = completedTasksWeight / weeksElapsed;
       }
@@ -465,7 +465,7 @@ export class Project extends Entity {
         date.getTime(),
         (targetTasks
           .filter((taskDef) => taskDef.targetDate >= date)
-          .map((td) => td.weighting)
+          .map((td) => td.estimated_hours)
           .reduce((prev, current) => prev + current, 0) || 0) / total,
       ];
 
@@ -475,7 +475,7 @@ export class Project extends Entity {
         (total -
           doneTasks
             .filter((task) => task.submissionDate && task.submissionDate <= date)
-            .map((task) => task.definition.weighting)
+            .map((task) => task.definition.estimated_hours)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];
@@ -486,7 +486,7 @@ export class Project extends Entity {
         (total -
           completedTasks
             .filter((task) => task.completionDate <= date)
-            .map((task) => task.definition.weighting)
+            .map((task) => task.definition.estimated_hours)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];

--- a/src/app/api/models/project.ts
+++ b/src/app/api/models/project.ts
@@ -404,7 +404,7 @@ export class Project extends Entity {
     const targetTasks = this.unit.taskDefinitionsForGrade(this.targetGrade);
 
     // get total value of all tasks assigned to this project
-    const total = targetTasks.map((td) => td.estimated_hours).reduce((prev, current, idx, array) => prev + current, 0);
+    const total = targetTasks.map((td) => td.predicted_effort).reduce((prev, current, idx, array) => prev + current, 0);
 
     // exit if no tasks or no weights
     if (targetTasks.length === 0 || total === 0) {
@@ -444,7 +444,7 @@ export class Project extends Entity {
       const weeksElapsed = MappingFunctions.weeksBetween(this.unit.startDate, today);
       if (weeksElapsed > 0) {
         const completedTasksWeight = readyOrCompleteTasks
-          .map((t) => t.definition.estimated_hours)
+          .map((t) => t.definition.predicted_effort)
           .reduce((prev, current, idx, arr) => prev + current, 0);
         completionRate = completedTasksWeight / weeksElapsed;
       }
@@ -465,7 +465,7 @@ export class Project extends Entity {
         date.getTime(),
         (targetTasks
           .filter((taskDef) => taskDef.targetDate >= date)
-          .map((td) => td.estimated_hours)
+          .map((td) => td.predicted_effort)
           .reduce((prev, current) => prev + current, 0) || 0) / total,
       ];
 
@@ -475,7 +475,7 @@ export class Project extends Entity {
         (total -
           doneTasks
             .filter((task) => task.submissionDate && task.submissionDate <= date)
-            .map((task) => task.definition.estimated_hours)
+            .map((task) => task.definition.predicted_effort)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];
@@ -486,7 +486,7 @@ export class Project extends Entity {
         (total -
           completedTasks
             .filter((task) => task.completionDate <= date)
-            .map((task) => task.definition.estimated_hours)
+            .map((task) => task.definition.predicted_effort)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -27,7 +27,7 @@ export class TaskDefinition extends Entity {
   abbreviation: string;
   name: string;
   description: string;
-  weighting: number;
+  estimated_hours: number;
   targetGrade: number;
   targetDate: Date;
   dueDate: Date;

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -28,6 +28,7 @@ export class TaskDefinition extends Entity {
   name: string;
   description: string;
   estimated_hours: number;
+  predicted_effort: number;
   targetGrade: number;
   targetDate: Date;
   dueDate: Date;
@@ -329,5 +330,8 @@ export class TaskDefinition extends Entity {
 
   public projectTask(project?: Project): Task | undefined {
     return project?.tasks?.find((p) => p.definition.id === this.id);
+  }
+  public get predictEffortUrl(): string {
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/units/${this.unit.id}/task_definitions/${this.id}/predict_effort`;
   }
 }

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -81,6 +81,8 @@ export class Unit extends Entity {
 
   d2lMapping: D2lAssessmentMapping;
 
+  allowEffortPredictions: boolean;
+
   public readonly learningOutcomesCache: EntityCache<LearningOutcome> =
     new EntityCache<LearningOutcome>();
   public readonly tutorialStreamsCache: EntityCache<TutorialStream> =

--- a/src/app/api/services/sidekiq-job.service.ts
+++ b/src/app/api/services/sidekiq-job.service.ts
@@ -13,7 +13,7 @@ export interface SidekiqJobEntry {
 
 @Injectable()
 export class SidekiqJobService extends CachedEntityService<SidekiqJob> {
-  protected readonly endpointFormat = 'sidekiq/:id:';
+  protected readonly endpointFormat = 'sidekiq/:id';
 
   public jobEntries: Map<string, SidekiqJobEntry> = new Map();
 

--- a/src/app/api/services/sidekiq-job.service.ts
+++ b/src/app/api/services/sidekiq-job.service.ts
@@ -13,7 +13,7 @@ export interface SidekiqJobEntry {
 
 @Injectable()
 export class SidekiqJobService extends CachedEntityService<SidekiqJob> {
-  protected readonly endpointFormat = 'sidekiq/:id';
+  protected readonly endpointFormat = 'sidekiq/:id:';
 
   public jobEntries: Map<string, SidekiqJobEntry> = new Map();
 

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -34,7 +34,7 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'abbreviation',
       'name',
       'description',
-      'weighting',
+      'estimated_hours',
       'targetGrade',
       'similarityLanguage',
       'hasJplagReport',

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -35,6 +35,7 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'name',
       'description',
       'estimated_hours',
+      'predicted_effort',
       'targetGrade',
       'similarityLanguage',
       'hasJplagReport',
@@ -272,5 +273,11 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
     const url = `${AppInjector.get(DoubtfireConstants).API_URL}/submission/units/${taskDefinition.unit.id}/task_definitions/${taskDefinition.id}/student_pdfs/zip`;
     const httpClient = AppInjector.get(HttpClient);
     return httpClient.get<SidekiqJob>(url);
+  }
+
+  public predictEffort(taskDefinition: TaskDefinition): Observable<SidekiqJob> {
+    const http = AppInjector.get(HttpClient);
+
+    return http.post<SidekiqJob>(taskDefinition.predictEffortUrl, {});
   }
 }

--- a/src/app/api/services/unit.service.ts
+++ b/src/app/api/services/unit.service.ts
@@ -257,6 +257,7 @@ export class UnitService extends CachedEntityService<Unit> {
       // 'groupMemberships', - map to group memberships
       'feedbackWarningThresholdDays',
       'feedbackOverflowThresholdDays',
+      'allowEffortPredictions',
     );
 
     this.mapping.addJsonKey(
@@ -288,6 +289,7 @@ export class UnitService extends CachedEntityService<Unit> {
       'allowStudentChangeTutorial',
       'feedbackWarningThresholdDays',
       'feedbackOverflowThresholdDays',
+      'allowEffortPredictions',
     );
   }
 

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -323,6 +323,7 @@ import {TutorNotesModalComponent} from './common/modals/tutor-notes-modal/tutor-
 import {FeedbackAppealModalComponent} from './tasks/modals/feedback-appeal-modal/feedback-appeal-modal.component';
 import {ConfirmModerationModalComponent} from './units/states/tasks/inbox/directives/moderation/confirm-moderation-modal/confirm-moderation-modal.component';
 import {TaskClaimComponent} from './units/states/tasks/inbox/directives/task-claim/task-claim.component';
+import { TaskDefinitionEffortComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component';
 
 // See https://stackoverflow.com/questions/55721254/how-to-change-mat-datepicker-date-format-to-dd-mm-yyyy-in-simplest-way/58189036#58189036
 const MY_DATE_FORMAT = {
@@ -407,6 +408,7 @@ const GANTT_CHART_CONFIG = {
     TaskDefinitionResourcesComponent,
     TaskDefinitionOverseerComponent,
     TaskDefinitionScormComponent,
+    TaskDefinitionEffortComponent,
     UnitAnalyticsComponent,
     StudentTutorialSelectComponent,
     StudentCampusSelectComponent,

--- a/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.component.html
@@ -201,6 +201,11 @@
       <mat-slide-toggle [(ngModel)]="unit.active">Active</mat-slide-toggle>
       <p>Set to false to hide unit from students and tutors.</p>
     </div>
+
+    <div>
+      <mat-slide-toggle [(ngModel)]="unit.allowEffortPredictions">Allow AI Effort Prediction</mat-slide-toggle>
+      <p>Set to false to disable running AI effort predictions on tasks belonging to this unit.</p>
+    </div>
   </mat-card>
 
   @if (overseerEnabled.value) {

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
@@ -114,6 +114,20 @@
     <section
       class="mb-0 rounded-xl bg-white p-4 scroll-mt-28"
       #sectionElement
+      data-section-id="effort-prediction"
+    >
+      <h3>Effort Prediction</h3>
+      <p class="font-normal text-gray-500 pb-2">
+        Use a regression model to determine the effort required for a task based on task definition values
+      </p>
+      <f-task-definition-effort [taskDefinition]="taskDefinition" [staffView]="true">
+      </f-task-definition-effort>
+    </section>
+
+    <mat-divider class="my-[25px]"></mat-divider>
+    <section
+      class="mb-0 rounded-xl bg-white p-4 scroll-mt-28"
+      #sectionElement
       data-section-id="discussion-prompts"
     >
       <h3>Discussion Prompts</h3>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.ts
@@ -27,6 +27,7 @@ type TaskDefinitionSectionId =
   | 'upload-requirements'
   | 'task-resources'
   | 'prerequisite-tasks'
+  | 'effort-prediction'
   | 'discussion-prompts'
   | 'task-assessment-automation'
   | 'scorm-test'
@@ -58,6 +59,7 @@ export class TaskDefinitionEditorComponent implements OnInit, AfterViewInit, OnC
     {id: 'upload-requirements', label: 'Upload Requirements'},
     {id: 'task-resources', label: 'Task Resources'},
     {id: 'prerequisite-tasks', label: 'Prerequisite Tasks'},
+    {id: 'effort-prediction', label: 'Effort Prediction'},
     {id: 'discussion-prompts', label: 'Discussion Prompts'},
     {id: 'task-assessment-automation', label: 'Task Assessment Automation'},
     {id: 'scorm-test', label: 'SCORM Test'},

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
@@ -1,0 +1,32 @@
+<!-- Row 1: Enable prediction -->
+<div class="mb-4">
+  <mat-checkbox [(ngModel)]="enablePrediction">Enable effort prediction</mat-checkbox>
+</div>
+
+<!-- Row 2: Button -->
+<div class="mb-4">
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="runPrediction()"
+    [disabled]="!enablePrediction"
+  >
+    Run prediction
+  </button>
+</div>
+
+<!-- Row 3: Manual input -->
+<div class="mb-4 gap-4">
+  <mat-form-field appearance="outline" class="w-full">
+    <mat-label>Predicted Effort</mat-label>
+
+    <input
+      matInput
+      type="number"
+      [(ngModel)]="taskDefinition.predicted_effort"
+      [disabled]="enablePrediction"
+      min="1"
+      max="100"
+    />
+  </mat-form-field>
+</div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
@@ -1,32 +1,57 @@
 <!-- Row 1: Enable prediction -->
-<div class="mb-4">
+<div>
   <mat-checkbox [(ngModel)]="enablePrediction">Enable effort prediction</mat-checkbox>
 </div>
 
-<!-- Row 2: Button -->
-<div class="mb-4">
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="runPrediction()"
-    [disabled]="!enablePrediction"
-  >
-    Run prediction
-  </button>
-</div>
+<div class="space-y-8">
+  <div class="flex gap-4 items-center">
+      <!-- Row 2: Button -->
+      <div>
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="runPrediction()"
+          [disabled]="!enablePrediction || isPredicting"
+        >
+          Run prediction
+        </button>
+      </div>
 
-<!-- Row 3: Manual input -->
-<div class="mb-4 gap-4">
-  <mat-form-field appearance="outline" class="w-full">
-    <mat-label>Predicted Effort</mat-label>
+      <mat-progress-spinner
+        *ngIf="isPredicting"
+        mode="indeterminate"
+        diameter="24">
+      </mat-progress-spinner>
 
-    <input
-      matInput
-      type="number"
-      [(ngModel)]="taskDefinition.predicted_effort"
-      [disabled]="enablePrediction"
-      min="1"
-      max="100"
-    />
-  </mat-form-field>
+      <span *ngIf="isPredicting">
+        {{ predictionStatus === 'queued' ? 'Queued...' :
+          predictionStatus === 'working' ? 'Running prediction...' :
+          'Processing...' }}
+      </span>
+
+      <span *ngIf="!isPredicting && predictionStatus === 'complete'" class="text-green-600">
+        ✔ Prediction complete
+      </span>
+
+      <span *ngIf="!isPredicting && predictionStatus === 'failed'" class="text-red-600">
+        ✖ Prediction failed
+      </span>
+  </div>
+
+
+  <!-- Row 3: Manual input -->
+  <div>
+    <mat-form-field appearance="outline" class="w-full">
+      <mat-label>Predicted Effort</mat-label>
+
+      <input
+        matInput
+        type="number"
+        [(ngModel)]="taskDefinition.predicted_effort"
+        [disabled]="enablePrediction || isPredicting"
+        min="1"
+        max="100"
+      />
+    </mat-form-field>
+  </div>
 </div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input } from '@angular/core';
+import { TaskDefinition } from 'src/app/api/models/task-definition';
+import { Unit } from 'src/app/api/models/unit';
+import { TaskDefinitionService } from 'src/app/api/services/task-definition.service';
+
+@Component({
+  selector: 'f-task-definition-effort',
+  templateUrl: 'task-definition-effort.component.html',
+  styleUrls: ['task-definition-effort.component.scss'],
+})
+export class TaskDefinitionEffortComponent {
+  @Input() taskDefinition: TaskDefinition;
+  @Input() staffView: boolean;
+  constructor(private TaskDefinitionService: TaskDefinitionService) {}
+  enablePrediction = true;
+
+  public get unit(): Unit {
+    return this.taskDefinition?.unit;
+  }
+
+  runPrediction() {
+    if (!this.taskDefinition || !this.taskDefinition.id) return;
+
+    this.TaskDefinitionService.predictEffort(this.taskDefinition).subscribe({
+      next: () => {
+        console.log('Prediction queued');
+      },
+      error: (err) => {
+        console.error('Prediction failed', err);
+      },
+    });
+  }
+}

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
@@ -1,33 +1,128 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { TaskDefinition } from 'src/app/api/models/task-definition';
 import { Unit } from 'src/app/api/models/unit';
+import { SidekiqJobService } from 'src/app/api/services/sidekiq-job.service';
 import { TaskDefinitionService } from 'src/app/api/services/task-definition.service';
+import { Subject, interval, switchMap, takeWhile, Subscription } from 'rxjs';
 
 @Component({
   selector: 'f-task-definition-effort',
   templateUrl: 'task-definition-effort.component.html',
   styleUrls: ['task-definition-effort.component.scss'],
 })
-export class TaskDefinitionEffortComponent {
+export class TaskDefinitionEffortComponent implements OnDestroy {
   @Input() taskDefinition: TaskDefinition;
   @Input() staffView: boolean;
-  constructor(private TaskDefinitionService: TaskDefinitionService) {}
+
+  constructor(
+    private TaskDefinitionService: TaskDefinitionService,
+    private SidekiqJobService: SidekiqJobService,
+  ) {}
+
   enablePrediction = true;
+
+  isPredicting = false;
+  predictionStatus: 'queued' | 'working' | 'retrying' | 'complete' | 'stopped' | 'failed' | 'interrupted';
+  jobId: string | null = null;
+
+  private pollSub?: Subscription;
 
   public get unit(): Unit {
     return this.taskDefinition?.unit;
   }
 
   runPrediction() {
-    if (!this.taskDefinition || !this.taskDefinition.id) return;
+    if (!this.taskDefinition?.id) return;
+
+    this.isPredicting = true;
+    this.predictionStatus = 'queued';
 
     this.TaskDefinitionService.predictEffort(this.taskDefinition).subscribe({
-      next: () => {
-        console.log('Prediction queued');
+      next: (res: any) => {
+        this.predictionStatus = 'working';
+        const jobId = res.job_id;
+        this.jobId = jobId;
+
+        const resultSubject = new Subject<any>();
+
+        this.SidekiqJobService.setJob(
+          jobId,
+          'Predicting effort',
+          resultSubject
+        );
+
+        this.pollJob(jobId, resultSubject);
       },
-      error: (err) => {
-        console.error('Prediction failed', err);
+      error: () => {
+        this.predictionStatus = 'failed';
+        this.isPredicting = false;
       },
     });
+  }
+
+  pollJob(jobId: string, resultSubject: Subject<any>) {
+    this.pollSub = interval(2000).pipe(
+      switchMap(() => this.SidekiqJobService.getSidekiqJob(jobId)),
+      takeWhile(job => job.status !== 'complete' && job.status !== 'failed', true)
+    ).subscribe({
+      next: (job) => {
+        this.predictionStatus = (job.status || 'working').toLowerCase() as any;
+
+        this.SidekiqJobService.setJob(
+          jobId,
+          'Predicting effort',
+          resultSubject,
+          job
+        );
+
+        if (job.status === 'complete') {
+          let result: any;
+
+          try {
+            result = typeof job.result === 'string'
+              ? JSON.parse(job.result)
+              : job.result;
+          } catch {
+            result = null;
+          }
+
+          this.taskDefinition.predicted_effort = Number(result?.predicted_effort ?? 0);
+
+          this.predictionStatus = 'complete';
+          this.stopPolling();
+        }
+
+        if (job.status === 'failed') {
+          this.predictionStatus = 'failed';
+          console.error('Job failed:', job.message || job.result);
+          this.stopPolling();
+        }
+      },
+      error: () => {
+        this.predictionStatus = 'failed';
+        this.cleanup(jobId);
+      }
+    });
+  }
+
+  stopPolling() {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
+    this.isPredicting = false;
+  }
+
+  cleanup(jobId: string) {
+    this.isPredicting = false;
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
+    this.SidekiqJobService.removeJob(jobId);
+  }
+
+  ngOnDestroy() {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
   }
 }

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
@@ -14,8 +14,8 @@
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="flex-grow">
-    <mat-label>Weight - Effort relative to other tasks.</mat-label>
-    <input matInput type="number" [(ngModel)]="taskDefinition.weighting" required />
+    <mat-label>Estimated hours required for completion.</mat-label>
+    <input matInput type="number" [(ngModel)]="taskDefinition.estimated_hours" required />
   </mat-form-field>
 </div>
 

--- a/src/app/units/states/edit/directives/unit-tasks-editor/unit-task-editor.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/unit-task-editor.component.ts
@@ -278,7 +278,7 @@ export class UnitTaskEditorComponent implements AfterViewInit {
     task.startDate = new Date();
     task.targetDate = addWeeks(new Date(), 2);
     task.uploadRequirements = [];
-    task.weighting = 4;
+    task.estimated_hours = 4;
     task.targetGrade = 0;
     task.restrictStatusUpdates = false;
     task.plagiarismWarnPct = 80;

--- a/src/app/visualisations/progress-burndown-chart.coffee
+++ b/src/app/visualisations/progress-burndown-chart.coffee
@@ -96,7 +96,7 @@ angular.module('doubtfire.visualisations.progress-burndown-chart', [])
         tickFormat: xAxisTickFormatDateFormat
         ticks: 8
       yAxis:
-        axisLabel: "Tasks Remaining"
+        axisLabel: "Effort Remaining"
         tickFormat: yAxisTickFormatPercentFormat
       color: colorFunction
       legendColor: colorFunction


### PR DESCRIPTION
# Background and Context

Currently, the task definition object contained a `weighting` field which, when populated, assisted students in understanding how much of their unit they had completed by finishing the task. This measure is implemented in a visualisation called the _Progress Burndown Chart_:

<img width="803" height="566" alt="image" src="https://github.com/user-attachments/assets/9b988af0-3665-42e8-b2ae-f970e28992e5" />

Unfortunately, weighting is not always filled out accurately or at all by tutors when creating task definitions. This leads to the chart feeling bad for students by way of inconsistency; sometimes submitting a Pass task reduces this Burndown chart by the same amount that a Distinction task does, even if much more effort was put into the distinction task.

The AI effort prediction feature aims to solve this task effort evaluation with an intelligent regressor trained on data from previous Task Definitions in OnTrack.

# Description

This pull request introduces the necessary front-end changes to introduce intelligent effort prediction of tasks to OnTrack.

 - changes the `weighting` field throughout the repo to `estimated_hours` to give meaning to the integer value in the task definition
 - introduces the `TaskDefinitionEffortComponent` component to the Task Definition editor along with the required Typescript logic to run a prediction, get the value from the Task Definition object, and allow manual setting of the field
<img width="1085" height="483" alt="image" src="https://github.com/user-attachments/assets/4187f3ab-5b82-4556-80d2-73ee0a5c65b2" />

- adds references to the `predicted_effort` value stored in the Rails app and the API URL for sending prediction job requests to Sidekiq
- changes the reference variable used by the Task Burndown Chart logic (`src/app/api/models/project.ts`) to `predicted_effort` from `weighting`
- adds a (currently unfunctioning) toggle to the Unit Details page to allow predictions at the unit level

## Dependencies

Depends on the changes to the API in [doubtfire-api PR95](https://github.com/thoth-tech/doubtfire-api/pull/95). Successful testing depends on the ML Service defined in [doubtfire-deploy PR37](https://github.com/thoth-tech/doubtfire-deploy/pull/37).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

`TODO`

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have requested a review from @macite and @jakerenzella on the Pull Request~
