### PR TITLE
refactor: simplify viewer wrapper bindings

### DIFF
--- a/src/app/units/states/tasks/viewer/viewer.coffee
+++ b/src/app/units/states/tasks/viewer/viewer.coffee
@@ -19,5 +19,5 @@ angular.module('doubtfire.units.states.tasks.viewer', [
 )
 
 .controller('TaskViewerStateCtrl', ($scope) ->
-  $scope.taskDefs = $scope.unit.taskDefinitions
+
 )

--- a/src/app/units/states/tasks/viewer/viewer.tpl.html
+++ b/src/app/units/states/tasks/viewer/viewer.tpl.html
@@ -1,1 +1,1 @@
-<f-tasks-viewer [task-defs]="taskDefs" [unit]="unit"></f-tasks-viewer>
+<f-tasks-viewer [task-defs]="unit.taskDefinitions" [unit]="unit"></f-tasks-viewer>


### PR DESCRIPTION
> Note: This is a cleaned-up version of PR #459, containing only the 
> relevant files (viewer.coffee and viewer.tpl.html).

## Summary
This PR simplifies the AngularJS viewer wrapper by removing unnecessary `$scope` bindings and passing data directly to the Angular component.

## Changes
* Removed `$scope.taskDefs` assignment from `viewer.coffee`
* Updated `viewer.tpl.html` to pass `unit.taskDefinitions` directly to `<f-tasks-viewer>`
* No changes to routing or overall structure

## Result
* Reduces dependency on AngularJS controller logic
* Moves data handling closer to the Angular component
* Keeps existing functionality unchanged

## Scope note
This PR is intentionally small and focuses only on simplifying the viewer wrapper. Further migration of AngularJS state (e.g., `viewer.coffee`, `tasks.coffee`) will be handled in subsequent PRs.