### PR TITLE
Pass unitRole into task dashboard

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.ts
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.ts
@@ -16,7 +16,8 @@ import {DashboardViews} from '../../selected-task.service';
 export class TaskDashboardComponent implements OnInit, OnChanges {
   @Input() task: Task;
   @Input() pdfUrl: string;
-
+  @Input() unitRole: any;
+  
   public DashboardViews = DashboardViews;
 
   public taskStatusData: any;

--- a/src/app/units/states/tasks/inbox/inbox.component.html
+++ b/src/app/units/states/tasks/inbox/inbox.component.html
@@ -28,7 +28,11 @@
     }
 
     <div fxFlex class="inbox-panel">
-      <f-task-dashboard [task]="taskData.selectedTask" [pdfUrl]="visiblePdfUrl"></f-task-dashboard>
+      <f-task-dashboard 
+        [task]="taskData.selectedTask"
+        [pdfUrl]="visiblePdfUrl"
+        [unitRole]="unitRole"
+      ></f-task-dashboard>
     </div>
     <div
       id="rightResizerEl"


### PR DESCRIPTION
Summary:
UnitRole was added to task-dashboard.component.ts as an input.
The unit was passed.Function from f-task-dashboard to inbox.component.html

Justification:
UnitRole was already being used by the tutor notes view in task-dashboard.component.html, but it was not being sent through correctly.

Testing
The application was run locally.
 Confirmed that the frontend was successfully rebuilt
Verified that the dashboard page loads correctly following the modification.