### PR TITLE
Add task dashboard header actions

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
@@ -1,3 +1,65 @@
+<div *ngIf="task" class="flex items-center justify-between px-4 py-2 border-b bg-white">
+  <h3 class="m-0 text-base font-medium">
+    {{ task.definition.name }}
+  </h3>
+
+  <div class="flex gap-2 items-center">
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="setCurrentView(DashboardViews.submission)"
+      *ngIf="selectedTaskService.hasSubmissionPdf"
+    >
+      View Submission
+    </button>
+
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="setCurrentView(DashboardViews.task)"
+      *ngIf="selectedTaskService.hasTaskSheet"
+    >
+      View Task Sheet
+    </button>
+
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="setCurrentView(DashboardViews.similarity)"
+      *ngIf="tutor"
+    >
+      View Similarities
+    </button>
+
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="setCurrentView(DashboardViews.overseer)"
+      *ngIf="overseerEnabled"
+    >
+      View Overseer Reports
+    </button>
+
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="downloadSubmission()"
+      *ngIf="selectedTaskService.hasSubmissionPdf"
+    >
+      Download PDF
+    </button>
+
+    <button
+      type="button"
+      class="px-3 py-1 border rounded"
+      (click)="downloadSubmittedFiles()"
+      *ngIf="selectedTaskService.hasSubmissionPdf"
+    >
+      Download Files
+    </button>
+  </div>
+</div>
+
 <div class="w-full h-full overflow-auto">
   <ng-container [ngSwitch]="currentView">
     <ng-template [ngSwitchCase]="DashboardViews.task">

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.ts
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.ts
@@ -16,6 +16,7 @@ import {DashboardViews} from '../../selected-task.service';
 export class TaskDashboardComponent implements OnInit, OnChanges {
   @Input() task: Task;
   @Input() pdfUrl: string;
+  @Input() unitRole: any;
 
   public DashboardViews = DashboardViews;
 
@@ -73,6 +74,10 @@ export class TaskDashboardComponent implements OnInit, OnChanges {
 
   showSubmissionHistoryModal() {
     this.taskAssessmentModal.show(this.task);
+  }
+
+  setCurrentView(view: DashboardViews): void {
+    this.selectedTaskService.currentView$.next(view);
   }
 
   downloadSubmission() {


### PR DESCRIPTION
Summary: -

- The transferred task dashboard component now has a header.
- The chosen task name was shown.
-  Added action buttons to view the work sheet, submission, overseer reports, downloads, and similarities
- A helper function for updating the chosen dashboard view has been added.

Testing

- The application was run locally.
- Verified that the dashboard page has correctly reloaded
- I looked for issues in the browser console.